### PR TITLE
[idl] Fixes for compile-time errors when converting new IDL declarations

### DIFF
--- a/compiler/test/data/idl/enumMemberEscaping.d.kt
+++ b/compiler/test/data/idl/enumMemberEscaping.d.kt
@@ -19,3 +19,7 @@ inline val A.Companion.E55: A get() = "e55".asDynamic().unsafeCast<A>()
 inline val A.Companion._5FF: A get() = "5ff".asDynamic().unsafeCast<A>()
 
 inline val A.Companion._55G: A get() = "55g".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.A_B: A get() = "a/b".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.A_B_C: A get() = "a/b+c".asDynamic().unsafeCast<A>()

--- a/compiler/test/data/idl/enumMemberEscaping.d.kt
+++ b/compiler/test/data/idl/enumMemberEscaping.d.kt
@@ -1,0 +1,21 @@
+import kotlin.js.*
+
+/* please, don't implement this interface! */
+@Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
+external interface A {
+    companion object
+}
+
+inline val A.Companion.AAA: A get() = "aaa".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.BBB: A get() = "BBB".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.CCC_DDD: A get() = "ccc-ddd".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.EMPTY: A get() = "".asDynamic().unsafeCast<A>()
+
+inline val A.Companion.E55: A get() = "e55".asDynamic().unsafeCast<A>()
+
+inline val A.Companion._5FF: A get() = "5ff".asDynamic().unsafeCast<A>()
+
+inline val A.Companion._55G: A get() = "55g".asDynamic().unsafeCast<A>()

--- a/compiler/test/data/idl/enumMemberEscaping.webidl
+++ b/compiler/test/data/idl/enumMemberEscaping.webidl
@@ -1,0 +1,3 @@
+enum A {
+    "aaa", "BBB", "ccc-ddd", "", "e55", "5ff", "55g"
+};

--- a/compiler/test/data/idl/enumMemberEscaping.webidl
+++ b/compiler/test/data/idl/enumMemberEscaping.webidl
@@ -1,3 +1,3 @@
 enum A {
-    "aaa", "BBB", "ccc-ddd", "", "e55", "5ff", "55g"
+    "aaa", "BBB", "ccc-ddd", "", "e55", "5ff", "55g", "a/b", "a/b+c"
 };

--- a/compiler/test/data/idl/mixinConflicts.d.kt
+++ b/compiler/test/data/idl/mixinConflicts.d.kt
@@ -3,5 +3,11 @@ import kotlin.js.*
 external abstract class PerformanceX
 
 external abstract class WindowX {
-    open val performance: PerformanceX
+    open var performance: PerformanceX
+}
+
+external abstract class SVGAnimatedStringX
+
+external abstract class SVGAElementX {
+    open val href: SVGAnimatedStringX
 }

--- a/compiler/test/data/idl/mixinConflicts.d.kt
+++ b/compiler/test/data/idl/mixinConflicts.d.kt
@@ -1,0 +1,7 @@
+import kotlin.js.*
+
+external abstract class PerformanceX
+
+external abstract class WindowX {
+    open val performance: PerformanceX
+}

--- a/compiler/test/data/idl/mixinConflicts.webidl
+++ b/compiler/test/data/idl/mixinConflicts.webidl
@@ -1,0 +1,13 @@
+interface PerformanceX {
+
+};
+
+interface mixin WindowOrWorkerGlobalScope {
+    readonly attribute PerformanceX performance;
+};
+
+interface WindowX {
+    readonly attribute PerformanceX performance;
+};
+
+WindowX includes WindowOrWorkerGlobalScope;

--- a/compiler/test/data/idl/mixinConflicts.webidl
+++ b/compiler/test/data/idl/mixinConflicts.webidl
@@ -7,7 +7,26 @@ interface mixin WindowOrWorkerGlobalScope {
 };
 
 interface WindowX {
-    readonly attribute PerformanceX performance;
+    attribute PerformanceX performance;
 };
 
 WindowX includes WindowOrWorkerGlobalScope;
+
+interface SVGAnimatedStringX {
+
+};
+
+interface SVGAElementX {
+
+};
+
+interface mixin SVGURIReference {
+    readonly attribute SVGAnimatedStringX href;
+};
+
+interface mixin HTMLHyperlinkElementUtils {
+    stringifier attribute USVString href;
+};
+
+SVGAElementX includes SVGURIReference;
+SVGAElementX includes HTMLHyperlinkElementUtils;

--- a/compiler/test/data/idl/partials.d.kt
+++ b/compiler/test/data/idl/partials.d.kt
@@ -27,3 +27,9 @@ inline fun B(a: Boolean? = true, b: Boolean? = false): B {
     o["b"] = b
     return o
 }
+
+external object C {
+    val x: Int
+    val y: Int
+    fun f()
+}

--- a/compiler/test/data/idl/partials.webidl
+++ b/compiler/test/data/idl/partials.webidl
@@ -20,3 +20,12 @@ dictionary B {
 partial dictionary B {
     boolean b = false;
 };
+
+partial namespace C {
+    readonly attribute long y;
+}
+
+namespace C {
+    readonly attribute long x;
+    void f();
+}

--- a/compiler/test/data/idl/types.d.kt
+++ b/compiler/test/data/idl/types.d.kt
@@ -16,6 +16,7 @@ external abstract class A {
     open var intSequence: Array<Int>
     open var promise: Promise<Unit>
     open var readArray: Array<out Int>
+    open var rec: dynamic
     fun f(x: Array<Int>): Array<Int>
     fun g(x: A<Int>): A<Int>
     fun h(): Any?

--- a/compiler/test/data/idl/types.d.kt
+++ b/compiler/test/data/idl/types.d.kt
@@ -5,6 +5,7 @@ external abstract class A {
     open var s2: String
     open var s3: String
     open var s4: String
+    open var s5: String
     open var nullableString: String?
     open var obj: dynamic
     open var nullableObject: dynamic

--- a/compiler/test/data/idl/types.webidl
+++ b/compiler/test/data/idl/types.webidl
@@ -3,6 +3,7 @@ interface A {
     attribute DOMString s2;
     attribute USVString s3;
     attribute String s4;
+    attribute CSSOMString s5;
     attribute DOMString? nullableString;
 
     attribute object obj;

--- a/compiler/test/data/idl/types.webidl
+++ b/compiler/test/data/idl/types.webidl
@@ -17,6 +17,7 @@ interface A {
 
     attribute Promise<void> promise;
     attribute FrozenArray<long> readArray;
+    attribute record<DOMString, long> rec;
 
     sequence<long> f(sequence<long> x);
     A<long> g(A<long> x);

--- a/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLEnumDeclaration.kt
+++ b/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLEnumDeclaration.kt
@@ -19,6 +19,8 @@ fun processEnumMember(memberName: String): String {
             .removeSurrounding("\"")
             .toUpperCase()
             .replace('-', '_')
+            .replace('/', '_')
+            .replace('+', '_')
             .addUnderscoreIfStartsWithNumber()
             .ifEmpty { "EMPTY" }
 }

--- a/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLEnumDeclaration.kt
+++ b/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLEnumDeclaration.kt
@@ -6,10 +6,19 @@ data class IDLEnumDeclaration(
         val partial: Boolean = false
 ) : IDLTopLevelDeclaration
 
+private fun String.addUnderscoreIfStartsWithNumber(): String {
+    return if (matches(Regex("^[0-9].*$"))) {
+        "_$this"
+    } else {
+        this
+    }
+}
+
 fun processEnumMember(memberName: String): String {
     return memberName
             .removeSurrounding("\"")
             .toUpperCase()
             .replace('-', '_')
+            .addUnderscoreIfStartsWithNumber()
             .ifEmpty { "EMPTY" }
 }

--- a/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLNamespaceDeclaration.kt
+++ b/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLNamespaceDeclaration.kt
@@ -3,5 +3,6 @@ package org.jetbrains.dukat.idlDeclarations
 data class IDLNamespaceDeclaration(
         val name: String,
         val attributes: List<IDLAttributeDeclaration>,
-        val operations: List<IDLOperationDeclaration>
+        val operations: List<IDLOperationDeclaration>,
+        val partial: Boolean
 ) : IDLTopLevelDeclaration

--- a/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLSingleTypeDeclaration.kt
+++ b/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLSingleTypeDeclaration.kt
@@ -10,6 +10,7 @@ data class IDLSingleTypeDeclaration(
 fun IDLSingleTypeDeclaration.isKnown(): Boolean {
     return name in setOf(
             "ByteString",
+            "CSSOMString",
             "DOMError",
             "DOMString",
             "String",

--- a/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLSingleTypeDeclaration.kt
+++ b/idl/idl-declarations/src/org/jetbrains/dukat/idlDeclarations/IDLSingleTypeDeclaration.kt
@@ -28,6 +28,7 @@ fun IDLSingleTypeDeclaration.isKnown(): Boolean {
             "object",
             "octet",
             "Promise",
+            "record",
             "sequence",
             "short",
             "unrestricteddouble",

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/IDLLowering.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/IDLLowering.kt
@@ -11,6 +11,7 @@ import org.jetbrains.dukat.idlDeclarations.IDLGetterDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLImplementsStatementDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLIncludesStatementDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLInterfaceDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLNamespaceDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLOperationDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLSetterDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLSingleTypeDeclaration
@@ -104,8 +105,15 @@ interface IDLLowering {
         )
     }
 
-    fun lowerEnumDeclaration(declaration: IDLEnumDeclaration) : IDLEnumDeclaration {
+    fun lowerEnumDeclaration(declaration: IDLEnumDeclaration): IDLEnumDeclaration {
         return declaration
+    }
+
+    fun lowerNamespaceDeclaration(declaration: IDLNamespaceDeclaration): IDLNamespaceDeclaration {
+        return declaration.copy(
+                attributes = declaration.attributes.map { lowerAttributeDeclaration(it) },
+                operations = declaration.operations.map { lowerOperationDeclaration(it) }
+        )
     }
 
     fun lowerTopLevelDeclaration(declaration: IDLTopLevelDeclaration): IDLTopLevelDeclaration {
@@ -116,6 +124,7 @@ interface IDLLowering {
             is IDLDictionaryDeclaration -> lowerDictionaryDeclaration(declaration)
             is IDLEnumDeclaration -> lowerEnumDeclaration(declaration)
             is IDLIncludesStatementDeclaration -> lowerIncludesStatementDeclaration(declaration)
+            is IDLNamespaceDeclaration -> lowerNamespaceDeclaration(declaration)
             else -> declaration
         }
     }

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/OverrideHelper.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/OverrideHelper.kt
@@ -1,0 +1,115 @@
+package org.jetbrains.dukat.idlLowerings
+
+import org.jetbrains.dukat.idlDeclarations.IDLAttributeDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLDictionaryDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLDictionaryMemberDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLGetterDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLInterfaceDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLOperationDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLSetterDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLSingleTypeDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLTypeDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLUnionTypeDeclaration
+
+
+internal class OverrideHelper(val context: MissingMemberContext) {
+    private fun getFirstLevelParents(declaration: IDLInterfaceDeclaration): List<IDLInterfaceDeclaration> {
+        return declaration.parents.mapNotNull { context.resolveInterface(it.name) }
+    }
+
+    fun getAllInterfaceParents(declaration: IDLInterfaceDeclaration): List<IDLInterfaceDeclaration> {
+        val firstLevelParents = getFirstLevelParents(declaration)
+        return firstLevelParents + firstLevelParents.flatMap { getAllInterfaceParents(it) }
+    }
+
+    fun getAllDictionaryParents(declaration: IDLDictionaryDeclaration): List<IDLDictionaryDeclaration> {
+        val firstLevelParents = declaration.parents.mapNotNull { context.resolveDictionary(it.name) }
+        return firstLevelParents + firstLevelParents.flatMap { getAllDictionaryParents(it) }
+    }
+
+    fun isOverriding(type: IDLTypeDeclaration, parentType: IDLTypeDeclaration): Boolean {
+        if (type == parentType) {
+            return true
+        }
+
+        if (type is IDLSingleTypeDeclaration && parentType is IDLSingleTypeDeclaration) {
+            val classLike = context.resolveInterface(type.name)
+                    ?: context.resolveDictionary(type.name)
+            val parentClassLike = context.resolveInterface(parentType.name)
+                    ?: context.resolveDictionary(parentType.name)
+            return when (classLike) {
+                is IDLInterfaceDeclaration -> parentClassLike in getAllInterfaceParents(classLike)
+                is IDLDictionaryDeclaration -> parentClassLike in getAllDictionaryParents(classLike)
+                else -> false
+            }
+        }
+
+        if (parentType is IDLUnionTypeDeclaration) {
+            return parentType.unionMembers.any { isOverriding(type, it) }
+        }
+
+        if (parentType == IDLSingleTypeDeclaration("any", null, false)) {
+            return true
+        }
+
+        return false
+    }
+
+    fun isOverriding(member: IDLDictionaryMemberDeclaration, parentMember: IDLDictionaryMemberDeclaration): Boolean {
+        return member.name == parentMember.name
+    }
+
+    fun isOverriding(member: IDLAttributeDeclaration, parentMember: IDLAttributeDeclaration): Boolean {
+        return member.name == parentMember.name &&
+                member.static == parentMember.static &&
+                isOverriding(member.type, parentMember.type)
+    }
+
+    fun isConflicting(member: IDLAttributeDeclaration, parentMember: IDLAttributeDeclaration): Boolean {
+        return member.name == parentMember.name && !isOverriding(member, parentMember)
+    }
+
+    fun isOverriding(member: IDLOperationDeclaration, parentMember: IDLOperationDeclaration): Boolean {
+        return member.name == parentMember.name &&
+                member.static == parentMember.static &&
+                member.arguments.size == parentMember.arguments.size &&
+                (member.arguments.isEmpty() ||
+                        !member.arguments.zip(parentMember.arguments) { a, b -> isOverriding(a.type, b.type) }.all { it })
+    }
+
+    fun isConflicting(member: IDLOperationDeclaration, parentMember: IDLOperationDeclaration): Boolean {
+        return isOverriding(member, parentMember) && !isOverriding(member.returnType, parentMember.returnType)
+    }
+
+    fun isOverriding(member: IDLGetterDeclaration, parentMember: IDLGetterDeclaration): Boolean {
+        return member.name == parentMember.name &&
+                isOverriding(member.valueType, parentMember.valueType) &&
+                isOverriding(member.key.type, parentMember.key.type)
+    }
+
+    fun isOverriding(member: IDLSetterDeclaration, parentMember: IDLSetterDeclaration): Boolean {
+        return member.name == parentMember.name &&
+                isOverriding(member.key.type, parentMember.key.type) &&
+                isOverriding(member.value.type, parentMember.value.type)
+    }
+
+}
+
+internal class MissingMemberContext : IDLLowering {
+    private val interfaces: MutableMap<String, IDLInterfaceDeclaration> = mutableMapOf()
+    private val dictionaries: MutableMap<String, IDLDictionaryDeclaration> = mutableMapOf()
+
+    override fun lowerInterfaceDeclaration(declaration: IDLInterfaceDeclaration): IDLInterfaceDeclaration {
+        interfaces[declaration.name] = declaration
+        return declaration
+    }
+
+    override fun lowerDictionaryDeclaration(declaration: IDLDictionaryDeclaration): IDLDictionaryDeclaration {
+        dictionaries[declaration.name] = declaration
+        return declaration
+    }
+
+    fun resolveInterface(name: String): IDLInterfaceDeclaration? = interfaces[name]
+
+    fun resolveDictionary(name: String): IDLDictionaryDeclaration? = dictionaries[name]
+}

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/OverrideHelper.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/OverrideHelper.kt
@@ -10,6 +10,7 @@ import org.jetbrains.dukat.idlDeclarations.IDLSetterDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLSingleTypeDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLTypeDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLUnionTypeDeclaration
+import org.jetbrains.dukat.idlDeclarations.changeComment
 
 
 internal class OverrideHelper(val context: MissingMemberContext) {
@@ -28,7 +29,7 @@ internal class OverrideHelper(val context: MissingMemberContext) {
     }
 
     private fun isOverriding(type: IDLTypeDeclaration, parentType: IDLTypeDeclaration): Boolean {
-        if (type == parentType) {
+        if (type.changeComment(null) == parentType.changeComment(null)) {
             return true
         }
 
@@ -75,7 +76,7 @@ internal class OverrideHelper(val context: MissingMemberContext) {
                 member.static == parentMember.static &&
                 member.arguments.size == parentMember.arguments.size &&
                 (member.arguments.isEmpty() ||
-                        !member.arguments.zip(parentMember.arguments) { a, b -> isOverriding(a.type, b.type) }.all { it })
+                        member.arguments.zip(parentMember.arguments) { a, b -> isOverriding(a.type, b.type) }.all { it })
     }
 
     fun isConflicting(member: IDLOperationDeclaration, parentMember: IDLOperationDeclaration): Boolean {

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addItemArrayLike.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addItemArrayLike.kt
@@ -48,7 +48,7 @@ private class ItemArrayLikeLowering : IDLLowering {
                 )),
                 operations = listOf(IDLOperationDeclaration(
                         name = "item",
-                        returnType = IDLSingleTypeDeclaration("any", null, false),
+                        returnType = IDLSingleTypeDeclaration("any", null, true),
                         arguments = listOf(IDLArgumentDeclaration(
                                 name = "index",
                                 type = IDLSingleTypeDeclaration("unsignedlong", null, false),

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addItemArrayLike.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addItemArrayLike.kt
@@ -4,6 +4,7 @@ import org.jetbrains.dukat.astCommon.toNameEntity
 import org.jetbrains.dukat.idlDeclarations.IDLArgumentDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLAttributeDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLFileDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLGetterDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLInterfaceDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLOperationDeclaration
 import org.jetbrains.dukat.idlDeclarations.IDLSimpleExtendedAttributeDeclaration
@@ -46,26 +47,24 @@ private class ItemArrayLikeLowering : IDLLowering {
                         readOnly = true,
                         override = false
                 )),
-                operations = listOf(IDLOperationDeclaration(
-                        name = "item",
-                        returnType = IDLSingleTypeDeclaration("any", null, true),
-                        arguments = listOf(IDLArgumentDeclaration(
-                                name = "index",
-                                type = IDLSingleTypeDeclaration("unsignedlong", null, false),
-                                defaultValue = null,
-                                optional = false,
-                                variadic = false
-                        )),
-                        static = false,
-                        override = false
-                )),
+                operations = listOf(),
                 primaryConstructor = null,
                 constructors = listOf(),
                 parents = listOf(),
                 extendedAttributes = listOf(
                         IDLSimpleExtendedAttributeDeclaration("NoInterfaceObject")
                 ),
-                getters = listOf(),
+                getters = listOf(IDLGetterDeclaration(
+                        name = "item",
+                        valueType = IDLSingleTypeDeclaration("any", null, true),
+                        key = IDLArgumentDeclaration(
+                                name = "index",
+                                type = IDLSingleTypeDeclaration("unsignedlong", null, false),
+                                defaultValue = null,
+                                optional = false,
+                                variadic = false
+                        )
+                )),
                 setters = listOf(),
                 callback = false,
                 generated = true,

--- a/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addMissingMembers.kt
+++ b/idl/idl-lowerings/src/org/jetbrains/dukat/idlLowerings/addMissingMembers.kt
@@ -1,93 +1,22 @@
 package org.jetbrains.dukat.idlLowerings
 
-import org.jetbrains.dukat.idlDeclarations.*
-
-
-private fun getFirstLevelParents(context: MissingMemberContext, declaration: IDLInterfaceDeclaration): List<IDLInterfaceDeclaration> {
-    return declaration.parents.mapNotNull { context.resolveInterface(it.name) }
-}
-
-private fun getAllInterfaceParents(context: MissingMemberContext, declaration: IDLInterfaceDeclaration): List<IDLInterfaceDeclaration> {
-    val firstLevelParents = getFirstLevelParents(context, declaration)
-    return firstLevelParents + firstLevelParents.flatMap { getAllInterfaceParents(context, it) }
-}
-
+import org.jetbrains.dukat.idlDeclarations.IDLAttributeDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLDictionaryDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLGetterDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLInterfaceDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLOperationDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLSetterDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLSingleTypeDeclaration
+import org.jetbrains.dukat.idlDeclarations.IDLSourceSetDeclaration
+import org.jetbrains.dukat.idlDeclarations.InterfaceKind
+import org.jetbrains.dukat.idlDeclarations.changeComment
 
 private class MissingMemberResolver(val context: MissingMemberContext) : IDLLowering {
 
-    fun getAllDictionaryParents(declaration: IDLDictionaryDeclaration): List<IDLDictionaryDeclaration> {
-        val firstLevelParents = declaration.parents.mapNotNull { context.resolveDictionary(it.name) }
-        return firstLevelParents + firstLevelParents.flatMap { getAllDictionaryParents(it) }
-    }
-
-    fun IDLTypeDeclaration.isOverriding(parentType: IDLTypeDeclaration): Boolean {
-        if (this == parentType) {
-            return true
-        }
-
-        if (this is IDLSingleTypeDeclaration && parentType is IDLSingleTypeDeclaration) {
-            val classLike = context.resolveInterface(name)
-                    ?: context.resolveDictionary(name)
-            val parentClassLike = context.resolveInterface(parentType.name)
-                    ?: context.resolveDictionary(parentType.name)
-            return when (classLike) {
-                is IDLInterfaceDeclaration -> parentClassLike in getAllInterfaceParents(context, classLike)
-                is IDLDictionaryDeclaration -> parentClassLike in getAllDictionaryParents(classLike)
-                else -> false
-            }
-        }
-
-        if (parentType is IDLUnionTypeDeclaration) {
-            return parentType.unionMembers.any { isOverriding(it) }
-        }
-
-        if (parentType == IDLSingleTypeDeclaration("any", null, false)) {
-            return true
-        }
-
-        return false
-    }
-
-    fun IDLDictionaryMemberDeclaration.isOverriding(parentMember: IDLDictionaryMemberDeclaration): Boolean {
-        return name == parentMember.name
-    }
-
-    fun IDLAttributeDeclaration.isOverriding(parentMember: IDLAttributeDeclaration): Boolean {
-        return name == parentMember.name &&
-                static == parentMember.static &&
-                type.isOverriding(parentMember.type)
-    }
-
-    fun IDLAttributeDeclaration.isConflicting(parentMember: IDLAttributeDeclaration): Boolean {
-        return name == parentMember.name && !isOverriding(parentMember)
-    }
-
-    fun IDLOperationDeclaration.isOverriding(parentMember: IDLOperationDeclaration): Boolean {
-        return name == parentMember.name &&
-                static == parentMember.static &&
-                arguments.size == parentMember.arguments.size &&
-                (arguments.isEmpty() ||
-                        !arguments.zip(parentMember.arguments) { a, b -> a.type.isOverriding(b.type) }.all { it })
-    }
-
-    fun IDLOperationDeclaration.isConflicting(parentMember: IDLOperationDeclaration): Boolean {
-        return isOverriding(parentMember) && !returnType.isOverriding(parentMember.returnType)
-    }
-
-    fun IDLGetterDeclaration.isOverriding(parentMember: IDLGetterDeclaration): Boolean {
-        return name == parentMember.name &&
-                valueType.isOverriding(parentMember.valueType) &&
-                key.type.isOverriding(parentMember.key.type)
-    }
-
-    fun IDLSetterDeclaration.isOverriding(parentMember: IDLSetterDeclaration): Boolean {
-        return name == parentMember.name &&
-                key.type.isOverriding(parentMember.key.type) &&
-                value.type.isOverriding(parentMember.value.type)
-    }
+    val helper = OverrideHelper(context)
 
     override fun lowerInterfaceDeclaration(declaration: IDLInterfaceDeclaration): IDLInterfaceDeclaration {
-        val allParents = getAllInterfaceParents(context, declaration)
+        val allParents = helper.getAllInterfaceParents(declaration)
         val newAttributes: MutableList<IDLAttributeDeclaration> = mutableListOf()
         val newOperations: MutableList<IDLOperationDeclaration> = mutableListOf()
         val conflictingAttributes: MutableList<IDLAttributeDeclaration> = mutableListOf()
@@ -101,15 +30,15 @@ private class MissingMemberResolver(val context: MissingMemberContext) : IDLLowe
         declaration.parents.forEach { parent ->
             val resolvedParent = context.resolveInterface(parent.name) ?: return@forEach
             var isConflicting = false
-            val currentParentAttributes = (getAllInterfaceParents(context, resolvedParent) + resolvedParent).flatMap { it.attributes }
-            val currentParentOperations = (getAllInterfaceParents(context, resolvedParent) + resolvedParent).flatMap { it.operations }
+            val currentParentAttributes = (helper.getAllInterfaceParents(resolvedParent) + resolvedParent).flatMap { it.attributes }
+            val currentParentOperations = (helper.getAllInterfaceParents(resolvedParent) + resolvedParent).flatMap { it.operations }
             allParentAttributes.forEach { attribute ->
-                if (currentParentAttributes.any { it.isConflicting(attribute) }) {
+                if (currentParentAttributes.any { helper.isConflicting(it, attribute) }) {
                     isConflicting = true
                 }
             }
             allParentOperations.forEach { operation ->
-                if (currentParentOperations.any { it.isConflicting(operation) }) {
+                if (currentParentOperations.any { helper.isConflicting(it, operation) }) {
                     isConflicting = true
                 }
             }
@@ -124,7 +53,7 @@ private class MissingMemberResolver(val context: MissingMemberContext) : IDLLowe
 
         allParents.forEach { parent ->
             parent.operations.forEach { parentOperation ->
-                if (declaration.operations.none { it.isOverriding(parentOperation) }) {
+                if (declaration.operations.none { helper.isOverriding(it, parentOperation) }) {
                     if (parentOperation.static || parent.kind == InterfaceKind.INTERFACE) {
                         newOperations += parentOperation.copy(
                                 arguments = parentOperation.arguments.map {
@@ -140,28 +69,28 @@ private class MissingMemberResolver(val context: MissingMemberContext) : IDLLowe
                         )
                     }
                 } else {
-                    conflictingOperations += declaration.operations.filter { it.isConflicting(parentOperation) }
+                    conflictingOperations += declaration.operations.filter { helper.isConflicting(it, parentOperation) }
                 }
             }
             parent.attributes.forEach { parentAttribute ->
-                if (declaration.attributes.none { it.isOverriding(parentAttribute) }) {
+                if (declaration.attributes.none { helper.isOverriding(it, parentAttribute) }) {
                     if (declaration.attributes.none { it.name == parentAttribute.name }) {
                         if (parentAttribute.static || parent.kind == InterfaceKind.INTERFACE) {
                             newAttributes += parentAttribute.copy(override = true)
                         }
                     } else {
-                        conflictingAttributes.addAll(declaration.attributes.filter { it.isConflicting(parentAttribute) })
+                        conflictingAttributes.addAll(declaration.attributes.filter { helper.isConflicting(it, parentAttribute) })
                     }
                 }
             }
             parent.getters.forEach { parentGetter ->
                 conflictingGetters += declaration.getters.filter {
-                    it.name == parentGetter.name && !it.isOverriding(parentGetter)
+                    it.name == parentGetter.name && !helper.isOverriding(it, parentGetter)
                 }
             }
             parent.setters.forEach { parentSetter ->
                 conflictingSetters += declaration.setters.filter {
-                    it.name == parentSetter.name && !it.isOverriding(parentSetter)
+                    it.name == parentSetter.name && !helper.isOverriding(it, parentSetter)
                 }
             }
         }
@@ -180,17 +109,20 @@ private class MissingMemberResolver(val context: MissingMemberContext) : IDLLowe
     }
 
     override fun lowerDictionaryDeclaration(declaration: IDLDictionaryDeclaration): IDLDictionaryDeclaration {
-        val newMembers = getAllDictionaryParents(declaration)
+        val newMembers = helper.getAllDictionaryParents(declaration)
                 .flatMap { it.members }.filter { parentMember ->
-                    declaration.members.none { it.isOverriding(parentMember) }
+                    declaration.members.none { helper.isOverriding(it, parentMember) }
                 }.map { it.copy(inherited = true) }
         return declaration.copy(members = declaration.members + newMembers)
     }
 }
 
 private class DuplicateRemover(val context: MissingMemberContext) : IDLLowering {
+
+    val helper = OverrideHelper(context)
+
     override fun lowerInterfaceDeclaration(declaration: IDLInterfaceDeclaration): IDLInterfaceDeclaration {
-        val allParents = getAllInterfaceParents(context, declaration)
+        val allParents = helper.getAllInterfaceParents(declaration)
         val duplicatedAttributes: MutableList<IDLAttributeDeclaration> = mutableListOf()
         val duplicatedOperations: MutableList<IDLOperationDeclaration> = mutableListOf()
         allParents.forEach { parent ->
@@ -224,25 +156,6 @@ private class DuplicateRemover(val context: MissingMemberContext) : IDLLowering 
         )
     }
 
-}
-
-private class MissingMemberContext : IDLLowering {
-    private val interfaces: MutableMap<String, IDLInterfaceDeclaration> = mutableMapOf()
-    private val dictionaries: MutableMap<String, IDLDictionaryDeclaration> = mutableMapOf()
-
-    override fun lowerInterfaceDeclaration(declaration: IDLInterfaceDeclaration): IDLInterfaceDeclaration {
-        interfaces[declaration.name] = declaration
-        return declaration
-    }
-
-    override fun lowerDictionaryDeclaration(declaration: IDLDictionaryDeclaration): IDLDictionaryDeclaration {
-        dictionaries[declaration.name] = declaration
-        return declaration
-    }
-
-    fun resolveInterface(name: String): IDLInterfaceDeclaration? = interfaces[name]
-
-    fun resolveDictionary(name: String): IDLDictionaryDeclaration? = dictionaries[name]
 }
 
 fun IDLSourceSetDeclaration.addMissingMembers(): IDLSourceSetDeclaration {

--- a/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
+++ b/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
@@ -242,7 +242,6 @@ fun IDLInterfaceDeclaration.convertToModel(): List<TopLevelModel> {
             operations.filterNot { it.static } +
             getters.filterNot { it.name == "get" } +
             setters.filterNot { it.name == "set" }).mapNotNull { it.process() }.distinct()
-    println(dynamicMemberModels)
     val staticMemberModels = (attributes.filter { it.static } +
             operations.filter { it.static }).mapNotNull { it.process() }.distinct()
 

--- a/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
+++ b/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
@@ -84,6 +84,7 @@ fun IDLSingleTypeDeclaration.process(): TypeValueModel {
                 "unsignedshort" -> "Short"
                 "boolean" -> "Boolean"
                 "ByteString" -> "String"
+                "CSSOMString" -> "String"
                 "DOMString" -> "String"
                 "String" -> "String"
                 "USVString" -> "String"

--- a/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
+++ b/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
@@ -242,6 +242,7 @@ fun IDLInterfaceDeclaration.convertToModel(): List<TopLevelModel> {
             operations.filterNot { it.static } +
             getters.filterNot { it.name == "get" } +
             setters.filterNot { it.name == "set" }).mapNotNull { it.process() }.distinct()
+    println(dynamicMemberModels)
     val staticMemberModels = (attributes.filter { it.static } +
             operations.filter { it.static }).mapNotNull { it.process() }.distinct()
 

--- a/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
+++ b/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
@@ -94,6 +94,7 @@ fun IDLSingleTypeDeclaration.process(): TypeValueModel {
                 "Promise" -> "Promise"
                 "object" -> "dynamic"
                 "DOMError" -> "dynamic"
+                "record" -> "dynamic"
                 "\$dynamic" -> "dynamic"
                 "any" -> "Any"
                 else -> name

--- a/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/DefinitionVisitor.kt
+++ b/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/DefinitionVisitor.kt
@@ -265,6 +265,14 @@ internal class DefinitionVisitor(private val extendedAttributes: List<IDLExtende
         return defaultResult()
     }
 
+    override fun visitMixinMember(ctx: WebIDLParser.MixinMemberContext): IDLTopLevelDeclaration {
+        when (val member = MemberVisitor().visit(ctx)) {
+            is IDLAttributeDeclaration -> myAttributes.add(member)
+            is IDLOperationDeclaration -> operations.add(member)
+        }
+        return defaultResult()
+    }
+
     override fun visitPartial(ctx: WebIDLParser.PartialContext): IDLTopLevelDeclaration {
         partial = true
         visitChildren(ctx)

--- a/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/DefinitionVisitor.kt
+++ b/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/DefinitionVisitor.kt
@@ -88,7 +88,8 @@ internal class DefinitionVisitor(private val extendedAttributes: List<IDLExtende
             DefinitionKind.NAMESPACE -> IDLNamespaceDeclaration(
                     name = name,
                     attributes = myAttributes,
-                    operations = operations
+                    operations = operations,
+                    partial = partial
             )
         }
     }

--- a/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/TypeVisitor.kt
+++ b/idl/idl-parser/src/org/jetbrains/dukat/idlParser/visitors/TypeVisitor.kt
@@ -96,6 +96,11 @@ internal class TypeVisitor(private var name: String = "",
         return defaultResult()
     }
 
+    override fun visitRecordType(ctx: WebIDLParser.RecordTypeContext): IDLTypeDeclaration {
+        name = ctx.getFirstValueOrNull()!!
+        return defaultResult()
+    }
+
     override fun visitTypeSuffix(ctx: WebIDLParser.TypeSuffixContext): IDLTypeDeclaration {
         val suffix = ctx.getFirstValueOrNull()
         if (suffix == "?") {

--- a/model-lowerings/src/org/jetbrains/dukat/commonLowerings/lowerOverrides.kt
+++ b/model-lowerings/src/org/jetbrains/dukat/commonLowerings/lowerOverrides.kt
@@ -132,6 +132,10 @@ private class OverrideResolver(val context: ModelContext) {
             return true
         }
 
+        if (otherParameterType is TypeValueModel && otherParameterType.value == IdentifierEntity("Any")) {
+            return true
+        }
+
         if ((this is TypeValueModel) && (otherParameterType is TypeValueModel)) {
 
             if (value == otherParameterType.value
@@ -147,10 +151,6 @@ private class OverrideResolver(val context: ModelContext) {
             if (classLike != null) {
                 return classLike.getKnownParents().contains(otherClassLike)
             }
-        }
-
-        if (otherParameterType is TypeValueModel && otherParameterType.value == IdentifierEntity("Any")) {
-            return true
         }
 
         return false


### PR DESCRIPTION
- Resolve conflicts in mixins
- Support for partial namespaces
- Escape enum member identifiers if they are starting with number
- Convert CSSOMString type to String, record types to dynamic
- Fix several bugs concerning mixins and overrides