### PR TITLE
Don't treat FQNs starting with <ROOT> as stdlib entities

### DIFF
--- a/compiler/test/data/typescript/escaping/escaping.d.kt
+++ b/compiler/test/data/typescript/escaping/escaping.d.kt
@@ -16,6 +16,8 @@ import org.w3c.performance.*
 import org.w3c.workers.*
 import org.w3c.xhr.*
 import `when`.`interface`
+import `when`.Promise
+import `fun`.Promise as _fun_Promise
 import `__`.`___`
 
 external var `val`: Any
@@ -73,7 +75,7 @@ external open class `is`<`interface`> {
     }
 }
 
-external fun <T, U> When(value: Promise<T>, transform: (param_val: T) -> U): Promise<U>
+external fun <T, U> When(value: Promise<T>, transform: (param_val: T) -> U): _fun_Promise<U>
 
 external var `_`: `___`
 

--- a/compiler/test/src/org/jetbrains/dukat/compiler/tests/extended/DescriptorTests.kt
+++ b/compiler/test/src/org/jetbrains/dukat/compiler/tests/extended/DescriptorTests.kt
@@ -74,7 +74,6 @@ class DescriptorTests {
                 "class/inheritance/overridesFromReferencedFile",
                 "class/inheritance/overridingStdLib",
                 "class/inheritance/simple",
-                "escaping/escaping",
                 "inheritance/missingMembers/ambiguousProperties",
                 "interface/inheritance/simple",
                 "interface/inheritance/withQualifiedParent",

--- a/model-lowerings/src/org/jetbrains/dukat/commonLowerings/addImports.kt
+++ b/model-lowerings/src/org/jetbrains/dukat/commonLowerings/addImports.kt
@@ -59,7 +59,7 @@ private class ImportResolver(private val packageName: NameEntity, private val im
         } else {
             val conflictingImport = resolvedImports.firstOrNull { (it.name.rightMost() == shortName) && (it.name != entityName) }
             if ((conflictingImport != null) && (entityName.isTopLevelImport())) {
-                val alias = IdentifierEntity(entityName.translate().replace(".", "_"))
+                val alias = IdentifierEntity(entityName.translate().replace(".", "_").filterNot { it == '`' })
                 resolvedImports.add(ImportModel(entityName, alias))
                 alias
             } else null

--- a/stdlib/src/org/jetbrains/dukat/stdlib/KotlinStdlibEntities.kt
+++ b/stdlib/src/org/jetbrains/dukat/stdlib/KotlinStdlibEntities.kt
@@ -552,7 +552,6 @@ val KotlinBuiltInEntities = setOf(
 )
 
 fun isStdLibEntity(fqName: NameEntity): Boolean {
-    val leftMost = fqName.leftMost()
-    val isLib = leftMost == IdentifierEntity("<ROOT>") || fqName.isTsStdlibPrefixed() || fqName.isKotlinStdlibPrefixed()
+    val isLib = fqName.isTsStdlibPrefixed() || fqName.isKotlinStdlibPrefixed()
     return isLib && KotlinStdlibEntities.contains(fqName.rightMost())
 }


### PR DESCRIPTION
fix #379 