### PR TITLE
fix(#444): add checks for recursive references inside type alias.

### DIFF
--- a/compiler/test/data/typescript/node_modules/typeAlias/recursiveUnion.d.kt
+++ b/compiler/test/data/typescript/node_modules/typeAlias/recursiveUnion.d.kt
@@ -1,0 +1,20 @@
+// [test] recursiveUnion.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface Result {
+    fun getValue(): dynamic /* `T$0`? | ReadonlyArray<RecursiveUnion>? */
+}

--- a/compiler/test/data/typescript/node_modules/typeAlias/recursiveUnion.d.ts
+++ b/compiler/test/data/typescript/node_modules/typeAlias/recursiveUnion.d.ts
@@ -1,0 +1,8 @@
+export type RecursiveUnion =
+    | null
+    | { ref: RecursiveUnion }
+    | ReadonlyArray<RecursiveUnion>
+
+export interface Result {
+    getValue(): RecursiveUnion;
+}


### PR DESCRIPTION
The problem was with recursive type alias like this:
```ts
type A = { ref: A } | Array<A>
```

This code became valid from TypeScript 3.7, but there was a problem inside the `TypeAliasResolveLowering` class with infinite processing of the code.