### PR TITLE
fix(#424): add stricter removing of unsupported JS names.

### DIFF
--- a/compiler/test/data/typescript/node_modules/escaping/escaping.d.kt
+++ b/compiler/test/data/typescript/node_modules/escaping/escaping.d.kt
@@ -40,6 +40,8 @@ external interface This {
     @nativeSetter
     operator fun set(key: String, value: Any)
     @nativeSetter
+    operator fun set(key: String, value: Number)
+    @nativeSetter
     operator fun set(key: String, value: Number?)
     var this_one_shouldnt_be_escaped: Boolean
     var `when`: String

--- a/compiler/test/data/typescript/node_modules/escaping/escaping.d.ts
+++ b/compiler/test/data/typescript/node_modules/escaping/escaping.d.ts
@@ -8,6 +8,8 @@ interface This {
     "this_one_shouldnt_be_escaped": boolean;
     ":authority"?: string;
     ".xxx": any;
+    'column:in_between': number;
+    'don.in.center': number;
     '3х': string;
     200: string;
     300?: number;

--- a/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
+++ b/idl/idl-models/src/org/jetbrains/dukat/idlModels/convertToModel.kt
@@ -465,9 +465,7 @@ private class IdlFileConverter(
                         IdentifierExpressionModel(
                                 IdentifierEntity("o")
                         ),
-                        IdentifierExpressionModel(
-                                IdentifierEntity("\"$name\"")
-                        )
+                        StringLiteralExpressionModel(name)
                 ),
                 IdentifierExpressionModel(
                         IdentifierEntity(name)
@@ -477,22 +475,36 @@ private class IdlFileConverter(
 
     fun IDLDictionaryDeclaration.generateFunctionBody(): List<StatementModel> {
         val functionBody: MutableList<StatementModel> = mutableListOf(
-                AssignmentStatementModel(
-                        //TODO: change to honest variable creation
-                        IdentifierExpressionModel(
-                                IdentifierEntity("val o")
-                        ),
-                        CallExpressionModel(
-                                IdentifierExpressionModel(
-                                        IdentifierEntity("js")
-                                ),
-                                listOf(
-                                        StringLiteralExpressionModel(
-                                                "({})"
-                                        )
-                                )
+            VariableModel(
+                name = IdentifierEntity("o"),
+                immutable = true,
+                inline = false,
+                external = false,
+                get = null,
+                set = null,
+                extend = null,
+                comment = null,
+                explicitlyDeclaredType = false,
+                typeParameters = listOf(),
+                annotations = mutableListOf(),
+                visibilityModifier = VisibilityModifierModel.DEFAULT,
+                type = TypeValueModel(
+                    value = IdentifierEntity("dynamic"),
+                    params = listOf(),
+                    fqName = null,
+                    metaDescription = null,
+                ),
+                initializer = CallExpressionModel(
+                    IdentifierExpressionModel(
+                        IdentifierEntity("js")
+                    ),
+                    listOf(
+                        StringLiteralExpressionModel(
+                            "({})"
                         )
+                    )
                 )
+            )
         )
         functionBody.addAll(members.map { it.convertToAssignmentStatementModel() })
         functionBody.add(


### PR DESCRIPTION
Change the logic of `getter/setters` creation from unsupported JS names for cases like this:
```ts
export interface A {
  'test@field: string;
}
```
```kotlin
// Previously compiled into: 
external interface A {
    var  test@field: String
}

// Currently compiled into:
external interface A {
    @nativeGetter
    operator fun get(key: String): String?
    @nativeSetter
    operator fun set(key: String, value: String)
}
```

### Questions to answer
1. I find that we have this removal logic only for interfaces here: https://github.com/Kotlin/dukat/blob/0263d1d1ed0b536f998c720d0c914bc0a3c01f84/model-lowerings/src/org/jetbrains/dukat/commonLowerings/removeUnsupportedJsNames.kt#L81 . Seems like we need the same logic for object and class types. Do we need to implement it?
