### PR TITLE
fix(#414): apply type parameters to generic constructor before inserting inside a child class

### DIFF
--- a/compiler/test/data/typescript/node_modules/class/constructor/missingGenericConstructor.d.kt
+++ b/compiler/test/data/typescript/node_modules/class/constructor/missingGenericConstructor.d.kt
@@ -1,0 +1,24 @@
+// [test] missingGenericConstructor.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class GrandParent<C>(id: C)
+
+external open class Parent<B>(id: B) : GrandParent<B>
+
+external open class Child<A>(id: A) : Parent<A>
+
+external open class SelfishChild(id: String) : Parent<String>

--- a/compiler/test/data/typescript/node_modules/class/constructor/missingGenericConstructor.d.ts
+++ b/compiler/test/data/typescript/node_modules/class/constructor/missingGenericConstructor.d.ts
@@ -1,0 +1,9 @@
+declare class GrandParent<C> {
+    constructor(id: C)
+}
+
+declare class Parent<B> extends GrandParent<B> {}
+
+declare class Child<A> extends Parent<A> {}
+
+declare class SelfishChild extends Parent<string> {}

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/IntroduceMissingConstructors.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/IntroduceMissingConstructors.kt
@@ -1,45 +1,74 @@
 import org.jetbrains.dukat.ownerContext.NodeOwner
 import org.jetbrains.dukat.toposort.toposort
+import org.jetbrains.dukat.tsLowerings.ResolveTypeParamsInConstructor
 import org.jetbrains.dukat.tsLowerings.TopLevelDeclarationResolver
 import org.jetbrains.dukat.tsmodel.ClassDeclaration
 import org.jetbrains.dukat.tsmodel.ConstructorDeclaration
 import org.jetbrains.dukat.tsmodel.ModuleDeclaration
 import org.jetbrains.dukat.tsmodel.SourceSetDeclaration
 import org.jetbrains.dukat.tsmodel.TopLevelDeclaration
+import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
 
 class IntroduceMissingConstructors : TopLevelDeclarationLowering {
     private lateinit var declarationResolver: TopLevelDeclarationResolver
-    private val parentConstructorsMap = mutableMapOf<String, List<ConstructorDeclaration>>()
+    private val parentConstructorsMap = mutableMapOf<String, ClassWithConstructors>()
 
-    override fun lowerClassDeclaration(declaration: ClassDeclaration, owner: NodeOwner<ModuleDeclaration>?): TopLevelDeclaration? {
-        val constructors = parentConstructorsMap[declaration.uid]
-        val declarationResolved = if (constructors.isNullOrEmpty() || declaration.parentEntities.isEmpty()) {
-            declaration
-        } else {
-            // TODO: this is a strange thing to do and I need to figure out how to avoid this
-            declaration.copy(members = (constructors + declaration.members).distinct())
+    private data class ClassWithConstructors(
+        val classDeclaration: ClassDeclaration,
+        val constructors: List<ConstructorDeclaration>
+    )
+
+    private fun ClassWithConstructors?.addConstructorsInto(declaration: ClassDeclaration): ClassDeclaration {
+        if (this == null || constructors.isEmpty() || declaration.parentEntities.isEmpty()) {
+            return declaration
         }
+        // TODO: this is a strange thing to do and I need to figure out how to avoid this
+        return declaration.copy(members = (constructors + declaration.members).distinct())
+    }
+
+    private fun ClassWithConstructors.getConstructorsWithResolvedTypeParams(actualTypes: List<ParameterValueDeclaration>) =
+        when {
+            classDeclaration.typeParameters.isEmpty() -> constructors
+            else -> {
+                val typesMapping = classDeclaration.typeParameters.withIndex().map { (index, type) ->
+                    val resolvedType = actualTypes.getOrNull(index) ?: type.defaultValue
+                    type.name to resolvedType!!
+                }.toMap()
+                val resolver = ResolveTypeParamsInConstructor(typesMapping)
+                constructors.map { resolver.lowerConstructorDeclaration(it, null) }
+            }
+        }
+
+
+    override fun lowerClassDeclaration(
+        declaration: ClassDeclaration,
+        owner: NodeOwner<ModuleDeclaration>?
+    ): TopLevelDeclaration? {
+        val classWithConstructors = parentConstructorsMap[declaration.uid]
+        val declarationResolved = classWithConstructors.addConstructorsInto(declaration)
         return super.lowerClassDeclaration(declarationResolved, owner)
     }
 
     override fun lower(source: SourceSetDeclaration): SourceSetDeclaration {
         declarationResolver = TopLevelDeclarationResolver(source)
 
-        val classDeclarations = declarationResolver.asIterable().filterIsInstance(ClassDeclaration::class.java).toposort { classDeclaration ->
-            classDeclaration.parentEntities.mapNotNull { declarationResolver.resolveRecursive(it.typeReference?.uid) as? ClassDeclaration }
-        }
-
-        classDeclarations.forEach { classDeclaration ->
-            val constructors = classDeclaration.members.filterIsInstance(ConstructorDeclaration::class.java)
-            val constructorsResolved = if (constructors.isEmpty()) {
-                classDeclaration.parentEntities.flatMap { parentEntity ->
-                    parentEntity.typeReference?.uid?.let { parentConstructorsMap[it] } ?: emptyList()
-                }
-            } else {
-                constructors
+        val classDeclarations =
+            declarationResolver.asIterable().filterIsInstance<ClassDeclaration>().toposort { classDeclaration ->
+                classDeclaration.parentEntities.mapNotNull { declarationResolver.resolveRecursive(it.typeReference?.uid) as? ClassDeclaration }
             }
 
-            parentConstructorsMap[classDeclaration.uid] = constructorsResolved
+        classDeclarations.forEach { classDeclaration ->
+            val constructors = classDeclaration.members.filterIsInstance<ConstructorDeclaration>()
+            val constructorsResolved = when {
+                constructors.isNotEmpty() -> constructors
+                else -> classDeclaration.parentEntities.flatMap { parentEntity ->
+                    val uid = parentEntity.typeReference?.uid
+                    val parentConstructors = uid?.let { parentConstructorsMap[it] }
+                    parentConstructors?.getConstructorsWithResolvedTypeParams(parentEntity.typeArguments) ?: emptyList()
+                }
+            }
+
+            parentConstructorsMap[classDeclaration.uid] = ClassWithConstructors(classDeclaration, constructorsResolved)
         }
 
 

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/ResolveTypeParamsInConstructor.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/ResolveTypeParamsInConstructor.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.dukat.tsLowerings
+
+import org.jetbrains.dukat.astCommon.NameEntity
+import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
+import org.jetbrains.dukat.tsmodel.types.TypeParamReferenceDeclaration
+
+class ResolveTypeParamsInConstructor(
+    private val typesMapping: Map<NameEntity, ParameterValueDeclaration>
+) : DeclarationLowering {
+    override fun lowerTypeParamReferenceDeclaration(declaration: TypeParamReferenceDeclaration): ParameterValueDeclaration =
+        typesMapping[declaration.value] ?: super.lowerTypeParamReferenceDeclaration(declaration)
+}


### PR DESCRIPTION
There is a problem with generic class constructors inserting.
```ts
class A<T> { constructor(arg: T }
class B extends A<string> {}
```
With current behavior, we just copy the constructor from class `A` to class `B` without any manipulation with type parameters.
Those changes provide a type parameter replacement with the actual parameter before the constructor copying