### PR TITLE
fix(#437): add ability to process recursive function typealiases.

### DIFF
--- a/ast-common/src/org/jetbrains/dukat/astCommon/ReccurentEntitiesDetector.kt
+++ b/ast-common/src/org/jetbrains/dukat/astCommon/ReccurentEntitiesDetector.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.dukat.astCommon
+
+class ReccurentEntitiesDetector<T> {
+    private val recursiveTypes = mutableSetOf<T>();
+    private val possibleRecursiveTypes = mutableMapOf<T, Int>();
+
+    fun isAlreadyProcessed(entity: T?): Boolean {
+        return entity != null && possibleRecursiveTypes.contains(entity)
+    }
+
+    fun wasRecursionFoundIn(entity: T?): Boolean {
+        return recursiveTypes.contains(entity)
+    }
+
+    fun addToPossibleRecursiveEntities(entity: T?) {
+        if (entity == null) return
+        val count = possibleRecursiveTypes[entity] ?: 0
+
+        if (count > 0) recursiveTypes.add(entity)
+
+        possibleRecursiveTypes[entity] = count + 1
+    }
+
+    fun removeFromPossibleRecursiveEntities(entity: T?) {
+        if (entity == null) return
+        val count = possibleRecursiveTypes[entity] ?: return
+
+        if (count == 1) {
+            possibleRecursiveTypes.remove(entity)
+        } else {
+            possibleRecursiveTypes[entity] = count - 1
+        }
+    }
+
+    inline fun <R> with(entity: T?, entityProcessing: (isAlreadyProcessed: Boolean) -> R): R {
+        val isRecursive = isAlreadyProcessed(entity)
+            .also { addToPossibleRecursiveEntities(entity) }
+
+        return entityProcessing(isRecursive)
+            .also { removeFromPossibleRecursiveEntities(entity) }
+    }
+}

--- a/compiler/test/data/typescript/node_modules/typeAlias/recursiveFunctionType.d.kt
+++ b/compiler/test/data/typescript/node_modules/typeAlias/recursiveFunctionType.d.kt
@@ -1,0 +1,25 @@
+// [test] recursiveFunctionType.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface Result {
+    var fn1: dynamic /* typealias RecursiveArgFn = dynamic */
+        get() = definedExternally
+        set(value) = definedExternally
+    var fn2: dynamic /* typealias RecursiveReturnFn = dynamic */
+        get() = definedExternally
+        set(value) = definedExternally
+}

--- a/compiler/test/data/typescript/node_modules/typeAlias/recursiveFunctionType.d.ts
+++ b/compiler/test/data/typescript/node_modules/typeAlias/recursiveFunctionType.d.ts
@@ -1,0 +1,7 @@
+export type RecursiveArgFn = (a: number, b: RecursiveArgFn[]) => void
+export type RecursiveReturnFn = (a: number) => RecursiveReturnFn
+
+export interface Result {
+    fn1: RecursiveArgFn
+    fn2: RecursiveReturnFn
+}


### PR DESCRIPTION
### Summary
There was a problem with recursive function types like this:
```ts
export type Foo = (next?: Foo) => void
export type Bar = (a: number) => Bar
```


### Related Issue

https://github.com/Kotlin/dukat/issues/437