### PR TITLE
fix(#415): replace static initializers with definedExternally.

### DIFF
--- a/ast-model/src/org/jetbrains/dukat/astModel/expressions/DefinedExternallyExpressionModel.kt
+++ b/ast-model/src/org/jetbrains/dukat/astModel/expressions/DefinedExternallyExpressionModel.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.dukat.astModel.expressions
+
+import org.jetbrains.dukat.astCommon.IdentifierEntity
+
+data class DefinedExternallyExpressionModel(val previousExpression: ExpressionModel?): ExpressionModel {
+   val identifier = IdentifierEntity("definedExternally")
+}

--- a/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.kt
+++ b/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.kt
@@ -1,0 +1,24 @@
+// [test] variablesWithInitializers.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external open class Foo {
+    companion object {
+        var FIELD1: Any = /* 20 */ definedExternally
+        var FIELD2: Any = /* 50 */ definedExternally
+        var FIELD3: Any = /* 100 */ definedExternally
+    }
+}

--- a/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.kt
+++ b/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.kt
@@ -17,8 +17,8 @@ import org.w3c.xhr.*
 
 external open class Foo {
     companion object {
-        var FIELD1: Any = /* 20 */ definedExternally
-        var FIELD2: Any = /* 50 */ definedExternally
-        var FIELD3: Any = /* 100 */ definedExternally
+        val FIELD1: Any = definedExternally /* 20 */
+        val FIELD2: Any = definedExternally /* 50 */
+        val FIELD3: Any = definedExternally /* 100 */
     }
 }

--- a/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.ts
+++ b/compiler/test/data/typescript/node_modules/class/static/variablesWithInitializers.d.ts
@@ -1,0 +1,5 @@
+export declare class Foo {
+    static readonly FIELD1 = 20;
+    static readonly FIELD2 = 50;
+    static readonly FIELD3 = 100;
+}

--- a/model-lowerings/src/org/jetbrains/dukat/commonLowerings/removeInitializersFromExternal.kt
+++ b/model-lowerings/src/org/jetbrains/dukat/commonLowerings/removeInitializersFromExternal.kt
@@ -1,0 +1,45 @@
+package org.jetbrains.dukat.commonLowerings
+
+import org.jetbrains.dukat.astModel.*
+import org.jetbrains.dukat.astModel.expressions.DefinedExternallyExpressionModel
+import org.jetbrains.dukat.model.commonLowerings.ModelLowering
+import org.jetbrains.dukat.model.commonLowerings.TopLevelModelLowering
+import org.jetbrains.dukat.ownerContext.NodeOwner
+import org.jetbrains.dukat.ownerContext.wrap
+
+private class RemoveInitializersFromExternalsLowering : TopLevelModelLowering {
+    override fun lowerClassModel(ownerContext: NodeOwner<ClassModel>, parentModule: ModuleModel): ClassModel {
+        val declaration = ownerContext.node
+        val members = declaration.members.map { lowerMemberModel(ownerContext.wrap(it)) }
+        return super.lowerClassModel(ownerContext.copy(node = declaration.copy(members = members)), parentModule)
+    }
+
+    override fun lowerObjectModel(ownerContext: NodeOwner<ObjectModel>, parentModule: ModuleModel): ObjectModel {
+        val declaration = ownerContext.node
+        val members = declaration.members.map { lowerMemberModel(ownerContext.wrap(it)) }
+        return super.lowerObjectModel(ownerContext.copy(node = declaration.copy(members = members)), parentModule)
+    }
+
+    private fun MemberModel.removeInitializerIfParentExternal(parent: CanHaveExternalModifierModel): MemberModel {
+        return if (!parent.external || this !is PropertyModel || initializer == null) {
+            this
+        } else {
+            copy(initializer = DefinedExternallyExpressionModel(initializer))
+        }
+    }
+
+    private fun lowerMemberModel(ownerContext: NodeOwner<MemberModel>): MemberModel {
+        val declaration = ownerContext.node
+
+        return when (val owner = ownerContext.owner?.node) {
+            is CanHaveExternalModifierModel -> declaration.removeInitializerIfParentExternal(owner)
+            else -> declaration
+        }
+    }
+}
+
+class RemoveInitializersFromExternals : ModelLowering {
+    override fun lower(module: ModuleModel): ModuleModel {
+        return RemoveInitializersFromExternalsLowering().lowerRoot(module, NodeOwner(module, null))
+    }
+}

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -434,7 +434,7 @@ private fun ExpressionModel.translate(): String {
         is IndexExpressionModel -> "${array.translate()}[${index.translate()}]"
         is CallExpressionModel -> translate()
         is DefinedExternallyExpressionModel -> previousExpression?.translate().let {
-           "${if (it != null) "/* $it */ " else ""}${identifier.translate()}"
+           "${identifier.translate()}${if (it != null) " /* $it */" else ""}"
         }
         is UnaryExpressionModel -> if (isPrefix) {
             "${operator.translate()}${operand.translate()}"

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -43,6 +43,7 @@ import org.jetbrains.dukat.astModel.expressions.IsExpressionModel
 import org.jetbrains.dukat.astModel.expressions.LambdaExpressionModel
 import org.jetbrains.dukat.astModel.expressions.NonNullExpressionModel
 import org.jetbrains.dukat.astModel.expressions.ParenthesizedExpressionModel
+import org.jetbrains.dukat.astModel.expressions.DefinedExternallyExpressionModel
 import org.jetbrains.dukat.astModel.expressions.PropertyAccessExpressionModel
 import org.jetbrains.dukat.astModel.expressions.SuperExpressionModel
 import org.jetbrains.dukat.astModel.expressions.ThisExpressionModel
@@ -432,6 +433,9 @@ private fun ExpressionModel.translate(): String {
         is PropertyAccessExpressionModel -> "${left.translate()}.${right.translate()}"
         is IndexExpressionModel -> "${array.translate()}[${index.translate()}]"
         is CallExpressionModel -> translate()
+        is DefinedExternallyExpressionModel -> previousExpression?.translate().let {
+           "${if (it != null) "/* $it */ " else ""}${identifier.translate()}"
+        }
         is UnaryExpressionModel -> if (isPrefix) {
             "${operator.translate()}${operand.translate()}"
         } else {

--- a/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
+++ b/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
@@ -14,6 +14,7 @@ import org.jetbrains.dukat.commonLowerings.RemoveUnusedGeneratedInterfaces
 import org.jetbrains.dukat.commonLowerings.ReplaceSimpleGeneratedInterfacesWithLambdas
 import org.jetbrains.dukat.commonLowerings.SeparateNonExternalEntities
 import org.jetbrains.dukat.commonLowerings.SubstituteTsStdLibEntities
+import org.jetbrains.dukat.commonLowerings.RemoveInitializersFromExternals
 import org.jetbrains.dukat.commonLowerings.merge.MergeClassLikesAndModuleDeclarations
 import org.jetbrains.dukat.commonLowerings.merge.MergeVarsAndInterfaces
 import org.jetbrains.dukat.model.commonLowerings.AddStandardImportsAndAnnotations
@@ -124,6 +125,7 @@ open class TypescriptLowerer(
                         SeparateNonExternalEntities(),
                         ReplaceSimpleGeneratedInterfacesWithLambdas(),
                         RemoveUnusedGeneratedInterfaces(),
+                        RemoveInitializersFromExternals(),
                         AddImports(),
                         AddStandardImportsAndAnnotations(addSuppressAnnotations)
                 )


### PR DESCRIPTION
### Summary

TypeScript declarations can contain declared classes static fields with initializers, like this:
```ts
declare class Foo {
  static readonly BAR = 4
}
```

Today, we compile the class in the next one:
```kotlin
external open class Foo {
  companion object {
    var BAR: Any = 4
  }
}
```

We have 2 problems here:
1. The read-only field is compiled into `var`
2. Kotlin external classes should not contain initializers inside their fields

Those changes fix the problem with initializers:
```kotlin
external open class Foo {
  companion object {
    var BAR: Any = /* 4 */ definedExternally
  }
}
```

### Related Issue

https://github.com/Kotlin/dukat/issues/415
