### PR TITLE
fix(#415): compile readonly fields into val.

### DIFF
--- a/compiler/test/data/typescript/node_modules/class/static/variables.d.kt
+++ b/compiler/test/data/typescript/node_modules/class/static/variables.d.kt
@@ -21,5 +21,9 @@ external open class Foo {
         var varAsNumber: Number
         var varAsBoolean: Boolean
         var varAsString: String
+        val valAsAny: Any
+        val valAsNumber: Number
+        val valAsBoolean: Boolean
+        val valAsString: String
     }
 }

--- a/compiler/test/data/typescript/node_modules/class/static/variables.d.ts
+++ b/compiler/test/data/typescript/node_modules/class/static/variables.d.ts
@@ -3,4 +3,9 @@ declare class Foo {
     static varAsNumber: number;
     static varAsBoolean: boolean;
     static varAsString: string;
+
+    static readonly valAsAny: any;
+    static readonly valAsNumber: number;
+    static readonly valAsBoolean: boolean;
+    static readonly valAsString: string;
 }

--- a/typescript/ts-converter/src/AstConverter.ts
+++ b/typescript/ts-converter/src/AstConverter.ts
@@ -309,6 +309,8 @@ export class AstConverter {
           res.push(this.astFactory.createModifierDeclaration(MODIFIER_KIND.EXPORT))
         } else if (modifier.kind == ts.SyntaxKind.DefaultKeyword) {
           res.push(this.astFactory.createModifierDeclaration(MODIFIER_KIND.DEFAULT))
+        } else if (modifier.kind == ts.SyntaxKind.ReadonlyKeyword) {
+          res.push(this.astFactory.createModifierDeclaration(MODIFIER_KIND.READONLY))
         }
       });
     }

--- a/typescript/ts-model-proto/src/tsdeclarations.proto
+++ b/typescript/ts-model-proto/src/tsdeclarations.proto
@@ -162,6 +162,7 @@ message ModifierDeclarationProto {
         EXPORT = 2;
         DEFAULT = 3;
         SYNTH_EXPORT_ASSIGNMENT = 4;
+        READONLY = 5;
     }
     MODIFIER_KIND token = 1;
 }

--- a/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/factory/convertProtobuf.kt
+++ b/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/factory/convertProtobuf.kt
@@ -203,6 +203,7 @@ fun ModifierDeclarationProto.convert(): ModifierDeclaration? {
         ModifierDeclarationProto.MODIFIER_KIND.DEFAULT -> ModifierDeclaration.DEFAULT_KEYWORD
         ModifierDeclarationProto.MODIFIER_KIND.EXPORT -> ModifierDeclaration.EXPORT_KEYWORD
         ModifierDeclarationProto.MODIFIER_KIND.STATIC -> ModifierDeclaration.STATIC_KEYWORD
+        ModifierDeclarationProto.MODIFIER_KIND.READONLY -> ModifierDeclaration.SYNTH_IMMUTABLE
         ModifierDeclarationProto.MODIFIER_KIND.SYNTH_EXPORT_ASSIGNMENT -> ModifierDeclaration.SYNTH_EXPORT_ASSIGNMENT
         else -> null
     }


### PR DESCRIPTION
### Summary

Currently we ignore `readonly` qualifier for class and interface fields.

```ts
declare class Foo {
  readonly BAR: string
}
```

Today, we compile the class in the next one:
```kotlin
external open class Foo {
  var BAR: String
}
```

Those changes provide compilation `readonly` fields into `val` variables:
```kotlin
external open class Foo {
    val BAR: String
}
```

### Related Issue

https://github.com/Kotlin/dukat/issues/415
