### PR TITLE
fix(#420): Merge only class like declaration with module declaration in corresponding lowering

### DIFF
--- a/compiler/test/data/typescript/node_modules/mergeDeclarations/namespaceWithInterfaceWithVar.d.kt
+++ b/compiler/test/data/typescript/node_modules/mergeDeclarations/namespaceWithInterfaceWithVar.d.kt
@@ -1,0 +1,21 @@
+// [test] namespaceWithInterfaceWithVar.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+@Suppress("EXTERNAL_DELEGATION", "NESTED_CLASS_IN_EXTERNAL_INTERFACE")
+external interface Foo {
+    companion object : Foo by definedExternally
+}

--- a/compiler/test/data/typescript/node_modules/mergeDeclarations/namespaceWithInterfaceWithVar.d.ts
+++ b/compiler/test/data/typescript/node_modules/mergeDeclarations/namespaceWithInterfaceWithVar.d.ts
@@ -1,0 +1,7 @@
+declare namespace Foo {
+}
+
+interface Foo {
+}
+
+declare var Foo: Foo;

--- a/model-lowerings/src/org/jetbrains/dukat/commonLowerings/merge/mergeClassLikesAndModuleDeclarations.kt
+++ b/model-lowerings/src/org/jetbrains/dukat/commonLowerings/merge/mergeClassLikesAndModuleDeclarations.kt
@@ -73,9 +73,13 @@ private fun ObjectModel?.merge(module: ModuleModel): ObjectModel? {
 }
 
 private fun ModuleModel.mergeClassLikesAndModuleDeclarations(classLikes: Map<NameEntity, MergeClassLikeData>): ModuleModel {
-    val declarationLowered = declarations.map { declaration ->
-        classLikes[name.appendLeft(declaration.name)]?.model ?: declaration
-    }
+    val declarationLowered = declarations
+        .map { declaration ->
+            when (declaration) {
+                is ClassLikeModel -> classLikes[name.appendLeft(declaration.name)]?.model ?: declaration
+                else -> declaration
+            }
+        }
     val submodulesLowered = submodules.filter {
         !classLikes.containsKey(it.mergeClassLikesAndModuleDeclarations(classLikes).name)
     }.map { it.mergeClassLikesAndModuleDeclarations(classLikes) }


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] There are new or updated unit tests validating those changes
* [ ] You've successfully run `./gradlew build` locally

And finally, please fill out this entire template so that we can review your PR as quickly as possible.
-->

### Summary

Now in merging of class likes and modules, all signatures with the same name lowered into interface.
In case when there is additional `var` with the same name, dukat generated two similar interfaces instead of one.
And there was no merging of such interface and `var`

### Related Issue

https://github.com/Kotlin/dukat/issues/420
