### PR TITLE
Expression extension translation

### DIFF
--- a/ast-model/src/org/jetbrains/dukat/astModel/ObjectModel.kt
+++ b/ast-model/src/org/jetbrains/dukat/astModel/ObjectModel.kt
@@ -8,13 +8,16 @@ import org.jetbrains.dukat.astModel.modifiers.VisibilityModifierModel
 
 data class ObjectModel(
         override val name: NameEntity,
-        val members: List<MemberModel>,
-
-        val parentEntities: List<HeritageModel>,
+        override val members: List<MemberModel>,
+        override val parentEntities: List<HeritageModel>,
         override val visibilityModifier: VisibilityModifierModel,
         override val comment: CommentEntity?,
-        override val external: Boolean
-) : MemberEntity, TopLevelModel, CanHaveExternalModifierModel
+        override val external: Boolean,
+) : ClassLikeModel, CanHaveExternalModifierModel {
+    override val annotations: List<AnnotationModel> = emptyList()
+    override val typeParameters: List<TypeParameterModel> = emptyList()
+    override val companionObject: ObjectModel? = null
+}
 
 fun ObjectModel?.mergeWith(otherModel: ObjectModel?): ObjectModel? {
     if (otherModel == null) {

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.kt
@@ -1,0 +1,30 @@
+// [test] singleConstructorWithGeneric.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface A<T> {
+    fun foo()
+}
+
+external interface AConstructor {
+    fun bar()
+}
+
+external open class Z<T>(a: T) : A<T> {
+    companion object : AConstructor
+}
+
+external open class B(a: Boolean) : Z<Boolean>

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.kt
@@ -24,7 +24,11 @@ external interface AConstructor {
 }
 
 external open class Z<T>(a: T) : A<T> {
-    companion object : AConstructor
+    override fun foo()
+
+    companion object : AConstructor {
+        override fun bar()
+    }
 }
 
 external open class B(a: Boolean) : Z<Boolean>

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGeneric.d.ts
@@ -1,0 +1,12 @@
+declare interface A<T> {
+    foo(): void;
+}
+
+declare interface AConstructor {
+    new<T>(a: T): A<T>
+    bar(): void
+}
+
+declare var Z: AConstructor
+
+declare class B extends Z<boolean> {}

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGenericDefault.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGenericDefault.d.kt
@@ -1,0 +1,32 @@
+// [test] singleConstructorWithGenericDefault.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface A<T> {
+    fun foo()
+}
+
+external interface AConstructor {
+    fun bar()
+}
+
+external open class Z<T>(a: T) : A<T> {
+    companion object : AConstructor
+}
+
+external open class Z__0 : Z<Number>
+
+external open class B(a: Number) : Z__0

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGenericDefault.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithGenericDefault.d.ts
@@ -1,0 +1,12 @@
+declare interface A<T> {
+    foo(): void;
+}
+
+declare interface AConstructor {
+    new<T = number>(a: T): A<T>
+    bar(): void
+}
+
+declare var Z: AConstructor
+
+declare class B extends Z {}

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithMultipleParents.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithMultipleParents.d.kt
@@ -1,4 +1,4 @@
-// [test] singleConstructorWithGenericDefault.module_resolved_name.kt
+// [test] singleConstructorWithMultipleParents.module_resolved_name.kt
 @file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
 
 import kotlin.js.*
@@ -15,22 +15,32 @@ import org.w3c.performance.*
 import org.w3c.workers.*
 import org.w3c.xhr.*
 
-external interface A<T> {
+external interface BaseA1 {
+    fun baz(a: Number): Number
+}
+
+external interface BaseA2 {
+    var value: String
+}
+
+external interface A : BaseA1, BaseA2 {
     fun foo()
 }
 
-external interface AConstructor {
+external interface AConstructor : BaseA1, BaseA2 {
     fun bar()
 }
 
-external open class Z<T>(a: T) : A<T> {
+external open class Z : A {
     override fun foo()
+    override fun baz(a: Number): Number
+    override var value: String
 
     companion object : AConstructor {
         override fun bar()
+        override fun baz(a: Number): Number
+        override var value: String
     }
 }
 
-external open class Z__0 : Z<Number>
-
-external open class B(a: Number) : Z__0
+external open class B : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithMultipleParents.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithMultipleParents.d.ts
@@ -1,0 +1,20 @@
+declare interface BaseA1 {
+   baz(a: number): number;
+}
+
+declare interface BaseA2 {
+  value: string;
+}
+
+declare interface A extends BaseA1, BaseA2 {
+    foo(): void;
+}
+
+declare interface AConstructor extends BaseA1, BaseA2 {
+    new(): A
+    bar(): void
+}
+
+declare var Z: AConstructor
+
+declare class B extends Z {}

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.kt
@@ -1,0 +1,30 @@
+// [test] singleConstructorWithParams.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface A {
+    fun foo()
+}
+
+external interface AConstructor {
+    fun bar()
+}
+
+external open class Z(a: String) : A {
+    companion object : AConstructor
+}
+
+external open class B(a: String) : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.kt
@@ -24,7 +24,11 @@ external interface AConstructor {
 }
 
 external open class Z(a: String) : A {
-    companion object : AConstructor
+    override fun foo()
+
+    companion object : AConstructor {
+        override fun bar()
+    }
 }
 
 external open class B(a: String) : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithParams.d.ts
@@ -1,0 +1,12 @@
+declare interface A {
+    foo(): void;
+}
+
+declare interface AConstructor {
+    new(a: string): A
+    bar(): void
+}
+
+declare var Z: AConstructor
+
+declare class B extends Z {}

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.kt
@@ -24,7 +24,11 @@ external interface AConstructor<T> {
 }
 
 external open class Z(a: Number) : A<Number> {
-    companion object : AConstructor<Number>
+    override fun foo()
+
+    companion object : AConstructor<Number> {
+        override fun bar()
+    }
 }
 
 external open class B(a: Number) : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.kt
@@ -1,0 +1,30 @@
+// [test] singleConstructorWithStaticGeneric.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface A<T> {
+    fun foo()
+}
+
+external interface AConstructor<T> {
+    fun bar()
+}
+
+external open class Z(a: Number) : A<Number> {
+    companion object : AConstructor<Number>
+}
+
+external open class B(a: Number) : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithStaticGeneric.d.ts
@@ -1,0 +1,12 @@
+declare interface A<T> {
+    foo(): void;
+}
+
+declare interface AConstructor<T> {
+    new(a: T): A<T>
+    bar(): void
+}
+
+declare var Z: AConstructor<number>
+
+declare class B extends Z {}

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.kt
@@ -24,7 +24,11 @@ external interface AConstructor {
 }
 
 external open class Z : A {
-    companion object : AConstructor
+    override fun foo()
+
+    companion object : AConstructor {
+        override fun bar()
+    }
 }
 
 external open class B : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.kt
@@ -1,0 +1,30 @@
+// [test] singleConstructorWithoutGenerics.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external interface A {
+    fun foo()
+}
+
+external interface AConstructor {
+    fun bar()
+}
+
+external open class Z : A {
+    companion object : AConstructor
+}
+
+external open class B : Z

--- a/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/constructSignature/singleConstructorWithoutGenerics.d.ts
@@ -1,0 +1,12 @@
+declare interface A {
+    foo(): void;
+}
+
+declare interface AConstructor {
+    new(): A
+    bar(): void
+}
+
+declare var Z: AConstructor
+
+declare class B extends Z {}

--- a/descriptors/src/org/jetbrains/dukat/descriptors/DescriptorTranslator.kt
+++ b/descriptors/src/org/jetbrains/dukat/descriptors/DescriptorTranslator.kt
@@ -527,7 +527,7 @@ private class DescriptorTranslator(val context: DescriptorContext) {
                 translateType(methodModel.type),
                 when (parent.kind) {
                     ClassKind.INTERFACE -> Modality.ABSTRACT
-                    ClassKind.OBJECT -> Modality.FINAL
+                    ClassKind.OBJECT -> if (methodModel.override.isNullOrEmpty() || !methodModel.open) Modality.FINAL else Modality.OPEN
                     else -> if (methodModel.open) Modality.OPEN else Modality.FINAL
                 },
                 DescriptorVisibilities.PUBLIC
@@ -638,7 +638,7 @@ private class DescriptorTranslator(val context: DescriptorContext) {
                         propertyModel.getter || propertyModel.setter -> Modality.OPEN
                         else -> Modality.ABSTRACT
                     }
-                    parent.kind == ClassKind.OBJECT -> Modality.FINAL
+                    parent.kind == ClassKind.OBJECT && propertyModel.override.isNullOrEmpty() -> Modality.FINAL
                     propertyModel.open -> Modality.OPEN
                     else -> Modality.FINAL
                 },

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/TopLevelModelLowering.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/TopLevelModelLowering.kt
@@ -64,6 +64,7 @@ interface TopLevelModelLowering : ModelStatementLowering, ModelLowering {
         return when (val declaration = ownerContext.node) {
             is InterfaceModel -> lowerInterfaceModel(NodeOwner(declaration, ownerContext), parentModule)
             is ClassModel -> lowerClassModel(NodeOwner(declaration, ownerContext), parentModule)
+            is ObjectModel -> lowerObjectModel(NodeOwner(declaration, ownerContext), parentModule)
             else -> declaration
         }
     }
@@ -73,7 +74,6 @@ interface TopLevelModelLowering : ModelStatementLowering, ModelLowering {
             is VariableModel -> lowerVariableModel(NodeOwner(declaration, ownerContext), parentModule)
             is FunctionModel -> lowerFunctionModel(NodeOwner(declaration, ownerContext), parentModule)
             is ClassLikeModel -> lowerClassLikeModel(NodeOwner(declaration, ownerContext), parentModule)
-            is ObjectModel -> lowerObjectModel(NodeOwner(declaration, ownerContext), parentModule)
             is EnumModel -> lowerEnumModel(NodeOwner(declaration, ownerContext), parentModule)
             is TypeAliasModel -> lowerTypeAliasModel(NodeOwner(declaration, ownerContext), parentModule)
             else -> raiseConcern("unknown TopLevelDeclaration ${declaration}") { declaration }

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/lowerOverrides.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/lowerOverrides.kt
@@ -5,6 +5,7 @@ import org.jetbrains.dukat.astCommon.NameEntity
 import org.jetbrains.dukat.astCommon.hasPrefix
 import org.jetbrains.dukat.astModel.ClassLikeModel
 import org.jetbrains.dukat.astModel.ClassModel
+import org.jetbrains.dukat.astModel.ObjectModel
 import org.jetbrains.dukat.astModel.FunctionTypeModel
 import org.jetbrains.dukat.astModel.InterfaceModel
 import org.jetbrains.dukat.astModel.LambdaParameterModel
@@ -315,9 +316,14 @@ private class ClassLikeOverrideResolver(
             member.lowerOverrides(parentMembers, context.getParents(classLike).mapNotNull { it.fqName })
         }
 
+        val companionObject = classLike.companionObject?.let {
+            ClassLikeOverrideResolver(context, inheritanceContext, it).resolve() as ObjectModel
+        }
+
         return when (classLike) {
-            is InterfaceModel -> classLike.copy(members = membersLowered)
-            is ClassModel -> classLike.copy(members = membersLowered)
+            is InterfaceModel -> classLike.copy(members = membersLowered, companionObject = companionObject)
+            is ClassModel -> classLike.copy(members = membersLowered, companionObject = companionObject)
+            is ObjectModel -> classLike.copy(members = membersLowered)
             else -> classLike
         }
     }

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -975,6 +975,7 @@ private fun ClassModel.translate(depth: Int, output: (String) -> Unit) {
 
     val members = members
     val staticMembers = companionObject?.members.orEmpty()
+    val companionObjectHeritages = translateHeritagModels(companionObject?.parentEntities.orEmpty())
 
     val hasMembers = members.isNotEmpty()
     val hasStaticMembers = staticMembers.isNotEmpty()
@@ -992,7 +993,7 @@ private fun ClassModel.translate(depth: Int, output: (String) -> Unit) {
         if (hasMembers) {
             output("")
         }
-        output(FORMAT_TAB.repeat(depth + 1) + "companion object${if (!hasStaticMembers) "" else " {"}")
+        output(FORMAT_TAB.repeat(depth + 1) + "companion object${companionObjectHeritages}${if (!hasStaticMembers) "" else " {"}")
     }
     if (hasStaticMembers) {
         staticMembers.flatMap { it.translate() }.map({ FORMAT_TAB.repeat(depth + 2) + it }).forEach {

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -979,7 +979,8 @@ private fun ClassModel.translate(depth: Int, output: (String) -> Unit) {
 
     val hasMembers = members.isNotEmpty()
     val hasStaticMembers = staticMembers.isNotEmpty()
-    val isBlock = hasMembers || hasStaticMembers
+    val hasCompanionParent = companionObjectHeritages.isNotEmpty()
+    val isBlock = hasMembers || hasStaticMembers || hasCompanionParent
 
     output(classDeclaration + if (isBlock) " {" else "")
 

--- a/translator/src/org/jetbrains/dukat/translator/ModelVisitor.kt
+++ b/translator/src/org/jetbrains/dukat/translator/ModelVisitor.kt
@@ -54,6 +54,7 @@ interface ModelVisitor {
         when (declaration) {
             is InterfaceModel -> processInterfaceModel(declaration)
             is ClassModel -> processClassModel(declaration)
+            is ObjectModel -> processObjectModel(declaration)
         }
     }
 
@@ -62,7 +63,6 @@ interface ModelVisitor {
             is VariableModel -> processVariableModel(declaration)
             is FunctionModel -> processFunctionModel(declaration)
             is ClassLikeModel -> processClassLikeModel(declaration)
-            is ObjectModel -> processObjectModel(declaration)
             is EnumModel -> processEnumNode(declaration)
             is TypeAliasModel -> processTypeAliasModel(declaration)
             else -> raiseConcern("unable to process TopLevelDeclaration ${declaration}") {  }

--- a/typescript/ts-converter/src/AstConverter.ts
+++ b/typescript/ts-converter/src/AstConverter.ts
@@ -440,6 +440,7 @@ export class AstConverter {
     }
 
     let typeReference: ReferenceEntity | null = null;
+
     if (ts.isImportSpecifier(declaration)) {
       let uid = this.createUid(declaration.name);
       if (uid) {
@@ -638,6 +639,12 @@ export class AstConverter {
         member.type ? this.convertType(member.type) : this.createTypeDeclaration("Unit"),
         this.convertTypeParams(member.typeParameters)
       )
+    } else if (ts.isConstructSignatureDeclaration(member)) {
+        return this.astFactory.createConstructSignatureDeclaration(
+            this.convertParameterDeclarations(member.parameters),
+            member.type ? this.convertType(member.type) : this.createTypeDeclaration("Unit"),
+            this.convertTypeParams(member.typeParameters)
+        )
     }
 
     return null;
@@ -768,7 +775,7 @@ export class AstConverter {
 
     if (Array.isArray(symbol.declarations)) {
       return symbol.declarations.find(decl => !ts.isModuleDeclaration(decl) &&
-              !ts.isVariableDeclaration(decl) && !ts.isPropertyDeclaration(decl) && !ts.isPropertySignature(decl) &&
+              !ts.isPropertyDeclaration(decl) && !ts.isPropertySignature(decl) &&
               !ts.isFunctionLike(decl))
     }
 

--- a/typescript/ts-converter/src/ast/AstFactory.ts
+++ b/typescript/ts-converter/src/ast/AstFactory.ts
@@ -81,7 +81,7 @@ import {
   UnionTypeDeclarationProto,
   VariableDeclarationProto,
   VariableLikeDeclarationProto,
-  WhileStatementDeclarationProto
+  WhileStatementDeclarationProto, ConstructSignatureDeclarationProto
 } from "declarations";
 import {tsInternals} from "../TsInternals";
 import * as ts from "../../.tsdeclarations/typescript";
@@ -140,6 +140,17 @@ export class AstFactory {
 
     let memberProto = new MemberDeclarationProto();
     memberProto.setCallsignature(callSignature);
+    return memberProto;
+  }
+
+  createConstructSignatureDeclaration(parameters: Array<ParameterDeclaration>, type: TypeDeclaration, typeParams: Array<TypeParameter>): MemberDeclaration {
+    let constructorSignature = new ConstructSignatureDeclarationProto();
+    constructorSignature.setParametersList(parameters);
+    constructorSignature.setType(type);
+    constructorSignature.setTypeparametersList(typeParams);
+
+    let memberProto = new MemberDeclarationProto();
+    memberProto.setConstructsignature(constructorSignature);
     return memberProto;
   }
 

--- a/typescript/ts-converter/src/ast/ast.ts
+++ b/typescript/ts-converter/src/ast/ast.ts
@@ -11,7 +11,8 @@ import {
     FunctionDeclarationProto,
     HeritageClauseDeclarationProto,
     ImportClauseDeclarationProto,
-    ImportEqualsDeclarationProto, ImportSpecifierDeclarationProto,
+    ImportEqualsDeclarationProto,
+    ImportSpecifierDeclarationProto,
     IndexSignatureDeclarationProto,
     InterfaceDeclarationProto,
     LiteralExpressionDeclarationProto,
@@ -32,7 +33,8 @@ import {
     TypeParameterDeclarationProto,
     TypeParamReferenceDeclarationProto,
     TypeReferenceDeclarationProto,
-    VariableDeclarationProto, ConstructSignatureDeclarationProto
+    VariableDeclarationProto,
+    ConstructSignatureDeclarationProto
 } from "declarations";
 import {IdentifierDeclarationProto, NameDeclarationProto} from "common_declarations";
 

--- a/typescript/ts-converter/src/ast/ast.ts
+++ b/typescript/ts-converter/src/ast/ast.ts
@@ -32,7 +32,7 @@ import {
     TypeParameterDeclarationProto,
     TypeParamReferenceDeclarationProto,
     TypeReferenceDeclarationProto,
-    VariableDeclarationProto
+    VariableDeclarationProto, ConstructSignatureDeclarationProto
 } from "declarations";
 import {IdentifierDeclarationProto, NameDeclarationProto} from "common_declarations";
 
@@ -41,6 +41,7 @@ export type BindingElementDeclaration = BindingElementDeclarationProto;
 export type CallSignatureDeclaration = CallSignatureDeclarationProto;
 export type ClassDeclaration = ClassDeclarationProto;
 export type ConstructorDeclaration = ConstructorDeclarationProto;
+export type ConstructSignatureDeclaration = ConstructSignatureDeclarationProto;
 export type DefinitionInfoDeclaration = DefinitionInfoDeclarationProto;
 export type EnumDeclaration = EnumDeclarationProto;
 export type EnumTokenDeclaration = EnumTokenDeclarationProto;

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/ApplyTypeParameters.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/ApplyTypeParameters.kt
@@ -4,9 +4,9 @@ import org.jetbrains.dukat.astCommon.NameEntity
 import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
 import org.jetbrains.dukat.tsmodel.types.TypeParamReferenceDeclaration
 
-class ResolveTypeParamsInConstructor(
-    private val typesMapping: Map<NameEntity, ParameterValueDeclaration>
-) : DeclarationLowering {
+typealias TypeMapping = Map<NameEntity, ParameterValueDeclaration>
+
+class ApplyTypeParameters(private val typesMapping: TypeMapping) : DeclarationLowering {
     override fun lowerTypeParamReferenceDeclaration(declaration: TypeParamReferenceDeclaration): ParameterValueDeclaration =
         typesMapping[declaration.value] ?: super.lowerTypeParamReferenceDeclaration(declaration)
 }

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/DeclarationLowering.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/DeclarationLowering.kt
@@ -52,9 +52,7 @@ interface DeclarationLowering : TopLevelDeclarationLowering, DeclarationStatemen
     fun lowerConstructorDeclaration(declaration: ConstructorDeclaration, owner: NodeOwner<MemberDeclaration>?): ConstructorDeclaration {
         return declaration.copy(
                 parameters = declaration.parameters.map { parameter -> lowerParameterDeclaration(parameter, owner.wrap(declaration)) },
-                typeParameters = declaration.typeParameters.map { typeParameter ->
-                    typeParameter.copy(constraints = typeParameter.constraints.map { constraint -> lowerParameterValue(constraint, owner.wrap(declaration)) })
-                },
+                typeParameters = declaration.typeParameters.map { typeParameter -> lowerTypeParameter(typeParameter, owner.wrap(declaration)) },
                 body = declaration.body?.let { lowerBlockStatement(it) }
         )
     }
@@ -63,9 +61,7 @@ interface DeclarationLowering : TopLevelDeclarationLowering, DeclarationStatemen
         return declaration.copy(
             type = lowerParameterValue(declaration.type, owner.wrap(declaration)),
             parameters = declaration.parameters.map { parameter -> lowerParameterDeclaration(parameter, owner.wrap(declaration)) },
-            typeParameters = declaration.typeParameters.map { typeParameter ->
-                typeParameter.copy(constraints = typeParameter.constraints.map { constraint -> lowerParameterValue(constraint, owner.wrap(declaration)) })
-            }
+            typeParameters = declaration.typeParameters.map { typeParameter -> lowerTypeParameter(typeParameter, owner.wrap(declaration)) }
         )
     }
 
@@ -73,9 +69,7 @@ interface DeclarationLowering : TopLevelDeclarationLowering, DeclarationStatemen
         return declaration.copy(
                 type = lowerParameterValue(declaration.type, owner.wrap(declaration)),
                 parameters = declaration.parameters.map { parameter -> lowerParameterDeclaration(parameter, owner.wrap(declaration)) },
-                typeParameters = declaration.typeParameters.map { typeParameter ->
-                    typeParameter.copy(constraints = typeParameter.constraints.map { constraint -> lowerParameterValue(constraint, owner.wrap(declaration)) })
-                }
+                typeParameters = declaration.typeParameters.map { typeParameter -> lowerTypeParameter(typeParameter, owner.wrap(declaration)) }
         )
     }
 

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/IntroduceMissingConstructors.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/IntroduceMissingConstructors.kt
@@ -1,6 +1,6 @@
 import org.jetbrains.dukat.ownerContext.NodeOwner
 import org.jetbrains.dukat.toposort.toposort
-import org.jetbrains.dukat.tsLowerings.ResolveTypeParamsInConstructor
+import org.jetbrains.dukat.tsLowerings.ApplyTypeParameters
 import org.jetbrains.dukat.tsLowerings.TopLevelDeclarationResolver
 import org.jetbrains.dukat.tsmodel.ClassDeclaration
 import org.jetbrains.dukat.tsmodel.ConstructorDeclaration
@@ -30,11 +30,11 @@ class IntroduceMissingConstructors : TopLevelDeclarationLowering {
         when {
             classDeclaration.typeParameters.isEmpty() -> constructors
             else -> {
-                val typesMapping = classDeclaration.typeParameters.withIndex().map { (index, type) ->
+                val typesMapping = classDeclaration.typeParameters.withIndex().associate { (index, type) ->
                     val resolvedType = actualTypes.getOrNull(index) ?: type.defaultValue
                     type.name to resolvedType!!
-                }.toMap()
-                val resolver = ResolveTypeParamsInConstructor(typesMapping)
+                }
+                val resolver = ApplyTypeParameters(typesMapping)
                 constructors.map { resolver.lowerConstructorDeclaration(it, null) }
             }
         }

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/removeConstructSignature.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/removeConstructSignature.kt
@@ -18,7 +18,7 @@ private class RemoveConstructSignatureLowering : DeclarationLowering {
         owner: NodeOwner<ModuleDeclaration>?
     ): TopLevelDeclaration? {
         return super.lowerClassLikeDeclaration(
-            declaration.copy(newMembers = declaration.members.filterConstructSignatures()),
+            declaration.copy(newMembers = declaration.members.filterNotConstructSignatures()),
             owner
         )
     }
@@ -28,13 +28,13 @@ private class RemoveConstructSignatureLowering : DeclarationLowering {
         owner: NodeOwner<ParameterOwnerDeclaration>?
     ): ParameterValueDeclaration {
         return super.lowerObjectLiteralDeclaration(
-            declaration.copy(members = declaration.members.filterConstructSignatures()),
+            declaration.copy(members = declaration.members.filterNotConstructSignatures()),
             owner
         )
     }
 
-    private fun List<MemberDeclaration>.filterConstructSignatures(): List<MemberDeclaration> {
-        return filter { it !is ConstructSignatureDeclaration }
+    private fun List<MemberDeclaration>.filterNotConstructSignatures(): List<MemberDeclaration> {
+        return filterNot { it is ConstructSignatureDeclaration }
     }
 }
 

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/removeConstructSignature.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/removeConstructSignature.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.dukat.tsLowerings
+
+import org.jetbrains.dukat.ownerContext.NodeOwner
+import org.jetbrains.dukat.tsmodel.copy
+import org.jetbrains.dukat.tsmodel.ConstructSignatureDeclaration
+import org.jetbrains.dukat.tsmodel.ClassLikeDeclaration
+import org.jetbrains.dukat.tsmodel.ModuleDeclaration
+import org.jetbrains.dukat.tsmodel.MemberDeclaration
+import org.jetbrains.dukat.tsmodel.TopLevelDeclaration
+import org.jetbrains.dukat.tsmodel.ParameterOwnerDeclaration
+import org.jetbrains.dukat.tsmodel.SourceSetDeclaration
+import org.jetbrains.dukat.tsmodel.types.ObjectLiteralDeclaration
+import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
+
+private class RemoveConstructSignatureLowering : DeclarationLowering {
+    override fun lowerClassLikeDeclaration(
+        declaration: ClassLikeDeclaration,
+        owner: NodeOwner<ModuleDeclaration>?
+    ): TopLevelDeclaration? {
+        return super.lowerClassLikeDeclaration(
+            declaration.copy(newMembers = declaration.members.filterConstructSignatures()),
+            owner
+        )
+    }
+
+    override fun lowerObjectLiteralDeclaration(
+        declaration: ObjectLiteralDeclaration,
+        owner: NodeOwner<ParameterOwnerDeclaration>?
+    ): ParameterValueDeclaration {
+        return super.lowerObjectLiteralDeclaration(
+            declaration.copy(members = declaration.members.filterConstructSignatures()),
+            owner
+        )
+    }
+
+    private fun List<MemberDeclaration>.filterConstructSignatures(): List<MemberDeclaration> {
+        return filter { it !is ConstructSignatureDeclaration }
+    }
+}
+
+class RemoveConstructSignature : TsLowering {
+    override fun lower(source: SourceSetDeclaration): SourceSetDeclaration {
+        return source.copy(sources = source.sources.map {
+            it.copy(root = RemoveConstructSignatureLowering().lowerSourceDeclaration(it.root))
+        })
+    }
+}

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/replaceExpressionExtension.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/replaceExpressionExtension.kt
@@ -121,7 +121,7 @@ private class ReplaceExpressionExtensionLowering(private val topLevelDeclaration
     private fun ConstructSignatureDeclaration.convertToConstructorDeclaration(): ConstructorDeclaration {
         return ConstructorDeclaration(
             parameters = parameters,
-            typeParameters = emptyList(),
+            typeParameters = typeParameters,
             modifiers = emptySet(),
             body = null
         )

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/replaceExpressionExtension.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/replaceExpressionExtension.kt
@@ -1,0 +1,140 @@
+package org.jetbrains.dukat.tsLowerings
+
+import TopLevelDeclarationLowering
+import org.jetbrains.dukat.astCommon.IdentifierEntity
+import org.jetbrains.dukat.ownerContext.NodeOwner
+import org.jetbrains.dukat.tsmodel.ClassDeclaration
+import org.jetbrains.dukat.tsmodel.ConstructorDeclaration
+import org.jetbrains.dukat.tsmodel.ConstructSignatureDeclaration
+import org.jetbrains.dukat.tsmodel.DefinitionInfoDeclaration
+import org.jetbrains.dukat.tsmodel.InterfaceDeclaration
+import org.jetbrains.dukat.tsmodel.HeritageClauseDeclaration
+import org.jetbrains.dukat.tsmodel.ModifierDeclaration
+import org.jetbrains.dukat.tsmodel.ModuleDeclaration
+import org.jetbrains.dukat.tsmodel.SourceSetDeclaration
+import org.jetbrains.dukat.tsmodel.TopLevelDeclaration
+import org.jetbrains.dukat.tsmodel.VariableDeclaration
+import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
+import org.jetbrains.dukat.tsmodel.types.TypeDeclaration
+
+private class ReplaceExpressionExtensionLowering(private val topLevelDeclarationResolver: TopLevelDeclarationResolver) : TopLevelDeclarationLowering {
+    override fun lowerTopLevelDeclaration(
+        declaration: TopLevelDeclaration,
+        owner: NodeOwner<ModuleDeclaration>?
+    ): TopLevelDeclaration? {
+        return when (declaration) {
+            is VariableDeclaration -> declaration.tryLowerToClassDeclaration(owner)
+            else -> super.lowerTopLevelDeclaration(declaration, owner)
+        }
+    }
+
+    private fun VariableDeclaration.tryLowerToClassDeclaration(owner: NodeOwner<ModuleDeclaration>?): TopLevelDeclaration? {
+        val topLevelDeclaration = type.getTopLevelDeclaration()
+        val constructorSignatureDeclarations = topLevelDeclaration.findAllConstructSignatureDeclarations()
+
+        if (constructorSignatureDeclarations.isEmpty()) {
+            return super.lowerVariableDeclaration(this, owner)
+        }
+
+        val typeParameters = type.getTypeParameters()
+        val appliedTypeParameters = topLevelDeclaration.getAppliedTypeParametersMap(typeParameters)
+
+        val classDeclaration = createClassWith(
+            uid = uid,
+            name = name,
+            owner = owner,
+            constructSignatures = constructorSignatureDeclarations.applyTypeParameters(appliedTypeParameters),
+            staticallyInheritedFrom = type as? TypeDeclaration
+        )
+
+        return super.lowerClassDeclaration(classDeclaration, owner);
+    }
+
+    private fun ParameterValueDeclaration.getTopLevelDeclaration(): TopLevelDeclaration? {
+        return (this as? TypeDeclaration)?.let { topLevelDeclarationResolver.resolve(it.typeReference) }
+    }
+
+    private fun ParameterValueDeclaration.getTypeParameters(): List<ParameterValueDeclaration> {
+        return (this as? TypeDeclaration)?.params ?: emptyList()
+    }
+
+    private fun TopLevelDeclaration?.findAllConstructSignatureDeclarations(): List<ConstructSignatureDeclaration> {
+        return (this as? InterfaceDeclaration)?.let { members.filterIsInstance<ConstructSignatureDeclaration>() }
+            ?: emptyList()
+    }
+
+    private fun TopLevelDeclaration?.getAppliedTypeParametersMap(typeParameters: List<ParameterValueDeclaration>): TypeMapping {
+        val interfaceDeclaration = this as? InterfaceDeclaration ?: return emptyMap()
+        return interfaceDeclaration.typeParameters.withIndex().associate { (index, type) ->
+            val resolvedType = typeParameters.getOrNull(index)
+                ?: type.defaultValue
+                // TODO: Handle multiple constraints
+                ?: type.constraints.firstOrNull()
+
+            type.name to resolvedType!!
+        }
+    }
+
+    private fun List<ConstructSignatureDeclaration>.applyTypeParameters(typeMapping: TypeMapping): List<ConstructSignatureDeclaration> {
+        val typeParametersResolver = ApplyTypeParameters(typeMapping)
+        return map { typeParametersResolver.lowerConstructSignatureDeclaration(it, null) }
+    }
+
+    private fun createClassWith(
+        name: String,
+        uid: String,
+        owner: NodeOwner<ModuleDeclaration>?,
+        constructSignatures: List<ConstructSignatureDeclaration>,
+        staticallyInheritedFrom: TypeDeclaration?
+    ): ClassDeclaration {
+        // TODO: Handle constructor overloading
+        val genericConstructor = constructSignatures.find { it.typeParameters.isNotEmpty() }
+        val constructorDeclarations = constructSignatures.map { it.convertToConstructorDeclaration() }
+        val parentEntities = constructSignatures.map { it.generateHeritageClauseDeclaration() }
+        val staticallyInherited = staticallyInheritedFrom?.generateHeritageClauseDeclaration()
+
+        return ClassDeclaration(
+            uid = uid,
+            name = IdentifierEntity(name),
+            members = constructorDeclarations,
+            typeParameters = genericConstructor?.typeParameters ?: emptyList(),
+            parentEntities = parentEntities,
+            modifiers = setOf(ModifierDeclaration.DECLARE_KEYWORD),
+            staticallyInherited = staticallyInherited?.let { listOf(it) } ?: emptyList(),
+            definitionsInfo = listOf(DefinitionInfoDeclaration(uid, owner?.node?.sourceName ?: "")),
+        )
+    }
+
+    private fun ConstructSignatureDeclaration.generateHeritageClauseDeclaration(): HeritageClauseDeclaration {
+        return (type as? TypeDeclaration).generateHeritageClauseDeclaration()
+    }
+
+    private fun TypeDeclaration?.generateHeritageClauseDeclaration(): HeritageClauseDeclaration {
+       return HeritageClauseDeclaration(
+           extending = false,
+           name = this?.value ?: IdentifierEntity(""),
+           typeArguments = this?.params ?: emptyList(),
+           typeReference = this?.typeReference
+       )
+    }
+
+    private fun ConstructSignatureDeclaration.convertToConstructorDeclaration(): ConstructorDeclaration {
+        return ConstructorDeclaration(
+            parameters = parameters,
+            typeParameters = emptyList(),
+            modifiers = emptySet(),
+            body = null
+        )
+    }
+
+}
+
+class ReplaceExpressionExtension : TsLowering {
+    override fun lower(source: SourceSetDeclaration): SourceSetDeclaration {
+        val topLevelDeclarationResolver = TopLevelDeclarationResolver(source)
+
+        return source.copy(sources = source.sources.map {
+            it.copy(root = ReplaceExpressionExtensionLowering(topLevelDeclarationResolver).lowerSourceDeclaration(it.root))
+        })
+    }
+}

--- a/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
+++ b/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
@@ -102,6 +102,7 @@ private val logger = Logging.logger("introduceModels")
 private fun MemberDeclaration.isStatic() = when (this) {
     is MethodDeclaration -> modifiers.contains(ModifierDeclaration.STATIC_KEYWORD)
     is PropertyDeclaration -> modifiers.contains(ModifierDeclaration.STATIC_KEYWORD)
+    is MethodSignatureDeclaration -> modifiers.contains(ModifierDeclaration.STATIC_KEYWORD)
     else -> false
 }
 

--- a/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
+++ b/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
@@ -677,16 +677,17 @@ private class DocumentConverter(
         val members = processMembers()
 
         val parentModelEntities = convertParentEntities(parentEntities)
+        val staticParentModelEntities = convertParentEntities(staticallyInherited)
 
         val external = rootIsDeclaration || hasDeclareModifier()
         return ClassModel(
                 name = name,
                 members = members.ownMembers,
-                companionObject = if (members.staticMembers.isNotEmpty()) {
+                companionObject = if (members.staticMembers.isNotEmpty() || staticallyInherited.isNotEmpty()) {
                     ObjectModel(
                             IdentifierEntity(""),
                             members.staticMembers,
-                            emptyList(),
+                            staticParentModelEntities,
                             VisibilityModifierModel.DEFAULT,
                             null,
                             external

--- a/typescript/ts-model-proto/src/tsdeclarations.proto
+++ b/typescript/ts-model-proto/src/tsdeclarations.proto
@@ -97,6 +97,12 @@ message CallSignatureDeclarationProto {
     repeated TypeParameterDeclarationProto typeParameters = 3;
 }
 
+message ConstructSignatureDeclarationProto {
+    repeated ParameterDeclarationProto parameters = 1;
+    ParameterValueDeclarationProto type = 2;
+    repeated TypeParameterDeclarationProto typeParameters = 3;
+}
+
 message ConstructorDeclarationProto {
     repeated ParameterDeclarationProto parameters = 1;
     repeated TypeParameterDeclarationProto typeParameters = 2;
@@ -180,6 +186,7 @@ message MemberDeclarationProto {
         MethodSignatureDeclarationProto methodSignature = 4;
         PropertyDeclarationProto property = 5;
         MethodDeclarationProto method = 6;
+        ConstructSignatureDeclarationProto constructSignature = 7;
     }
 }
 

--- a/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/ClassDeclaration.kt
+++ b/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/ClassDeclaration.kt
@@ -10,5 +10,6 @@ data class ClassDeclaration(
         override val parentEntities: List<HeritageClauseDeclaration>,
         override val modifiers: Set<ModifierDeclaration>,
         override val definitionsInfo: List<DefinitionInfoDeclaration>,
-        override val uid: String
+        override val uid: String,
+        val staticallyInherited: List<HeritageClauseDeclaration> = emptyList()
 ) : ClassLikeDeclaration, ExpressionDeclaration, WithModifiersDeclaration

--- a/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/ConstructSignatureDeclaration.kt
+++ b/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/ConstructSignatureDeclaration.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.dukat.tsmodel
+
+import org.jetbrains.dukat.tsmodel.types.ParameterValueDeclaration
+
+data class ConstructSignatureDeclaration(
+    override val parameters: List<ParameterDeclaration>,
+    override val type: ParameterValueDeclaration,
+    override val typeParameters: List<TypeParameterDeclaration>
+) : CallableMemberDeclaration, ParameterOwnerDeclaration, FunctionLikeDeclaration

--- a/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/factory/convertProtobuf.kt
+++ b/typescript/ts-model/src/org/jetbrains/dukat/tsmodel/factory/convertProtobuf.kt
@@ -12,6 +12,7 @@ import org.jetbrains.dukat.tsmodel.CallSignatureDeclaration
 import org.jetbrains.dukat.tsmodel.CaseDeclaration
 import org.jetbrains.dukat.tsmodel.ClassDeclaration
 import org.jetbrains.dukat.tsmodel.ConstructorDeclaration
+import org.jetbrains.dukat.tsmodel.ConstructSignatureDeclaration
 import org.jetbrains.dukat.tsmodel.ContinueStatementDeclaration
 import org.jetbrains.dukat.tsmodel.DefinitionInfoDeclaration
 import org.jetbrains.dukat.tsmodel.EnumDeclaration
@@ -113,6 +114,7 @@ import org.jetbrains.dukat.tsmodelproto.CaseDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.ClassDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.ConditionalExpressionDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.ConstructorDeclarationProto
+import org.jetbrains.dukat.tsmodelproto.ConstructSignatureDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.ContinueStatementDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.DefinitionInfoDeclarationProto
 import org.jetbrains.dukat.tsmodelproto.ElementAccessExpressionDeclarationProto
@@ -512,6 +514,14 @@ fun CallSignatureDeclarationProto.convert(): CallSignatureDeclaration {
     )
 }
 
+fun ConstructSignatureDeclarationProto.convert(): ConstructSignatureDeclaration {
+    return ConstructSignatureDeclaration(
+        parametersList.map { it.convert() },
+        type.convert(),
+        typeParametersList.map { it.convert() }
+    )
+}
+
 fun MemberDeclarationProto.convert(): MemberDeclaration {
     return when {
         hasConstructorDeclaration() -> constructorDeclaration.convert()
@@ -519,6 +529,7 @@ fun MemberDeclarationProto.convert(): MemberDeclaration {
         hasProperty() -> property.convert()
         hasIndexSignature() -> indexSignature.convert()
         hasCallSignature() -> callSignature.convert()
+        hasConstructSignature() -> constructSignature.convert()
         hasMethod() -> method.convert()
         else -> throw Exception("unknown MemberEntityProto: ${this}")
     }
@@ -814,7 +825,7 @@ fun ExpressionDeclarationProto.convert(): ExpressionDeclaration {
         hasParenthesizedExpression() -> parenthesizedExpression.convert()
         hasSpreadExpression() -> spreadExpression.convert()
         hasUnknownExpression() -> unknownExpression.convert()
-        else -> throw Exception("unknown expression: ${this}")
+        else -> throw Exception("unknown expression: $this")
     }
 }
 
@@ -833,7 +844,7 @@ fun StatementDeclarationProto.convert(): StatementDeclaration {
         hasForStatement() -> forStatement.convert()
         hasSwitchStatement() -> switchStatement.convert()
         hasForOfStatement() -> forOfStatement.convert()
-        else -> throw Exception("unknown statement: ${this}")
+        else -> throw Exception("unknown statement: $this")
     }
 }
 

--- a/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
+++ b/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
@@ -48,6 +48,7 @@ import org.jetbrains.dukat.tsLowerings.ProcessNullabilityChecks
 import org.jetbrains.dukat.tsLowerings.ProcessOptionalMethods
 import org.jetbrains.dukat.tsLowerings.RemoveThisParameters
 import org.jetbrains.dukat.tsLowerings.RenameImpossibleDeclarations
+import org.jetbrains.dukat.tsLowerings.ReplaceExpressionExtension
 import org.jetbrains.dukat.tsLowerings.ResolveCollections
 import org.jetbrains.dukat.tsLowerings.ResolveDefaultTypeParams
 import org.jetbrains.dukat.tsLowerings.ResolveLambdaParents
@@ -68,6 +69,7 @@ open class TypescriptLowerer(
     override fun lower(sourceSet: SourceSetDeclaration): SourceSetModel {
         val declarations = sourceSet
                 .lower(
+                        ReplaceExpressionExtension(),
                         IntroduceMissingConstructors(),
                         RemoveThisParameters(),
                         MergeModules(),

--- a/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
+++ b/typescript/ts-translator/src/org/jetbrains/dukat/ts/translator/TypescriptLowerer.kt
@@ -47,6 +47,7 @@ import org.jetbrains.dukat.tsLowerings.ProcessForOfStatements
 import org.jetbrains.dukat.tsLowerings.ProcessNullabilityChecks
 import org.jetbrains.dukat.tsLowerings.ProcessOptionalMethods
 import org.jetbrains.dukat.tsLowerings.RemoveThisParameters
+import org.jetbrains.dukat.tsLowerings.RemoveConstructSignature
 import org.jetbrains.dukat.tsLowerings.RenameImpossibleDeclarations
 import org.jetbrains.dukat.tsLowerings.ReplaceExpressionExtension
 import org.jetbrains.dukat.tsLowerings.ResolveCollections
@@ -70,6 +71,7 @@ open class TypescriptLowerer(
         val declarations = sourceSet
                 .lower(
                         ReplaceExpressionExtension(),
+                        RemoveConstructSignature(),
                         IntroduceMissingConstructors(),
                         RemoveThisParameters(),
                         MergeModules(),


### PR DESCRIPTION
### Summary

Currently, we just ignore any construct signatures and as a result, have a problem with so common declarations like this:
```ts
declare interface InstanceApi {
  foo(): void
}

declare interface StaticApi {
  bar(): void
  new(): InstanceApi
}

declare var SomeClass: StaticApi

/* ... */

declare class AnotherClass extends SomeClass {}
```

I proposed to analyze interfaces, classes, and type aliases on a construct signature existence and generate classes like this:
```kotlin
external interface InstanceApi {
  fun foo()
}

external interface StaticApi {
  fun bar()
}

external class SomeClass: InstanceApi {
  companion object : StaticApi
}

/* ... */

external class AnotherClass : SomeClass
```

### Related Issue

https://github.com/Kotlin/dukat/issues/404