### PR TITLE
fix(#381): add support of stdlib identifier collisions.

### DIFF
--- a/compiler/src/org/jetbrains/dukat/compiler/translator/IdlInputTranslator.kt
+++ b/compiler/src/org/jetbrains/dukat/compiler/translator/IdlInputTranslator.kt
@@ -22,6 +22,7 @@ import org.jetbrains.dukat.idlLowerings.specifyEventHandlerTypes
 import org.jetbrains.dukat.idlModels.convertToModel
 import org.jetbrains.dukat.idlParser.parseIDL
 import org.jetbrains.dukat.idlReferenceResolver.IdlReferencesResolver
+import org.jetbrains.dukat.model.commonLowerings.TranslationContext
 import org.jetbrains.dukat.model.commonLowerings.EscapeIdentificators
 import org.jetbrains.dukat.model.commonLowerings.LowerOverrides
 import org.jetbrains.dukat.model.commonLowerings.ModelContextAwareLowering
@@ -35,6 +36,7 @@ private fun alwaysPublic(): VisibilityModifierResolver = object : VisibilityModi
 }
 
 class IdlInputTranslator(private val nameResolver: IdlReferencesResolver) : InputTranslator<String> {
+    private val translationContext: TranslationContext = TranslationContext()
 
     fun translateSet(fileName: String): SourceSetModel {
         return parseIDL(fileName, nameResolver)
@@ -52,10 +54,8 @@ class IdlInputTranslator(private val nameResolver: IdlReferencesResolver) : Inpu
                 .addOverloadsForCallbacks()
                 .convertToModel()
                 .lower(
-                        ModelContextAwareLowering()
-                                .lower { context, inheritanceContext ->
-                                    LowerOverrides(context, inheritanceContext)
-                                },
+                        ModelContextAwareLowering(translationContext),
+                        LowerOverrides(translationContext),
                         EscapeIdentificators(),
                         AddExplicitGettersAndSetters()
                 )

--- a/compiler/test/data/typescript/node_modules/names/nameCollision.d.kt
+++ b/compiler/test/data/typescript/node_modules/names/nameCollision.d.kt
@@ -1,0 +1,29 @@
+// [test] nameCollision.module_resolved_name.kt
+@file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS")
+
+import kotlin.js.*
+import org.khronos.webgl.*
+import org.w3c.dom.*
+import org.w3c.dom.events.*
+import org.w3c.dom.parsing.*
+import org.w3c.dom.svg.*
+import org.w3c.dom.url.*
+import org.w3c.fetch.*
+import org.w3c.files.*
+import org.w3c.notifications.*
+import org.w3c.performance.*
+import org.w3c.workers.*
+import org.w3c.xhr.*
+
+external object Number {
+    fun foo(): kotlin.Any
+}
+
+external interface Any {
+    fun foo(value: Boolean): kotlin.Number
+}
+
+external open class Nothing {
+    open val value: kotlin.Number
+    open fun foo(a: Any, b: kotlin.Nothing?): Boolean
+}

--- a/compiler/test/data/typescript/node_modules/names/nameCollision.d.ts
+++ b/compiler/test/data/typescript/node_modules/names/nameCollision.d.ts
@@ -1,0 +1,10 @@
+declare var Number: { new(): any, foo(): any }
+
+declare interface Any {
+    foo(value: boolean): number;
+}
+
+declare class Nothing {
+    public readonly value: number;
+    public foo(a: Any, b: null): Boolean;
+}

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/CollisionContext.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/CollisionContext.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.dukat.model.commonLowerings
+
+typealias FileId = String
+typealias LocalCollisions = Set<String>
+typealias CollisionMap = MutableMap<FileId, LocalCollisions>
+
+class CollisionContext {
+    private val collisionMap: CollisionMap = mutableMapOf()
+
+    fun getCollisionsForTheFile(id: FileId): LocalCollisions {
+        return collisionMap.getOrDefault(id, emptySet())
+    }
+
+    fun putFileCollision(id: FileId, localCollisionSet: LocalCollisions) {
+        collisionMap[id] = localCollisionSet
+    }
+}

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/IntroduceAmbiguousInterfaceMembers.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/IntroduceAmbiguousInterfaceMembers.kt
@@ -8,7 +8,7 @@ import org.jetbrains.dukat.astModel.PropertyModel
 import org.jetbrains.dukat.model.commonLowerings.overrides.InheritanceContext
 import org.jetbrains.dukat.ownerContext.NodeOwner
 
-private class AmbiguousInterfaceLowering(private val modelContext: ModelContext, private val inheritanceContext: InheritanceContext) : ModelWithOwnerTypeLowering {
+private class AmbiguousInterfaceLowering(private val translationContext: TranslationContext) : ModelWithOwnerTypeLowering {
 
     private fun MemberModel.asKey(): NameEntity? {
         return when (this) {
@@ -19,7 +19,7 @@ private class AmbiguousInterfaceLowering(private val modelContext: ModelContext,
 
     override fun lowerInterfaceModel(ownerContext: NodeOwner<InterfaceModel>, parentModule: ModuleModel): InterfaceModel {
         val node = ownerContext.node
-        val parents = modelContext.getParents(node)
+        val parents = translationContext.modelContext.getParents(node)
 
         if (parents.size < 2) {
             return super.lowerInterfaceModel(ownerContext, parentModule)
@@ -40,8 +40,8 @@ private class AmbiguousInterfaceLowering(private val modelContext: ModelContext,
     }
 }
 
-class IntroduceAmbiguousInterfaceMembers(private val modelContext: ModelContext, private val inheritanceContext: InheritanceContext) : ModelLowering {
+class IntroduceAmbiguousInterfaceMembers(private val translationContext: TranslationContext) : ModelLowering {
     override fun lower(module: ModuleModel): ModuleModel {
-        return AmbiguousInterfaceLowering(modelContext, inheritanceContext).lowerRoot(module, NodeOwner(module, null))
+        return AmbiguousInterfaceLowering(translationContext).lowerRoot(module, NodeOwner(module, null))
     }
 }

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/ModelContextAwareLowering.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/ModelContextAwareLowering.kt
@@ -1,39 +1,29 @@
 package org.jetbrains.dukat.model.commonLowerings
 
 import org.jetbrains.dukat.astModel.ClassLikeModel
+import org.jetbrains.dukat.astModel.ModuleModel
 import org.jetbrains.dukat.astModel.SourceSetModel
 import org.jetbrains.dukat.toposort.Graph
 import org.jetbrains.dukat.model.commonLowerings.overrides.InheritanceContext
 
-private fun ModelContext.buildInheritanceGraph(): Graph<ClassLikeModel> {
-    val graph = Graph<ClassLikeModel>()
-
-    getClassLikeIterable().forEach { classLike ->
-        getAllParents(classLike).forEach { resolvedClassLike ->
-            graph.addEdge(classLike, resolvedClassLike.classLike)
-        }
-    }
-
-    return graph
-}
-
-class ModelContextAwareLowering : ComposableModelLowering {
-    internal lateinit var modelContext: ModelContext
-    internal lateinit var inheritanceContext: InheritanceContext
-    private val factories = mutableListOf<(ModelContext, InheritanceContext) -> ModelLowering>()
-
-    override val lowerings: List<ModelLowering>
-        get() = factories.map { factory -> factory(modelContext, inheritanceContext) }
-
-
-    fun lower(factory: (ModelContext, InheritanceContext) -> ModelLowering): ModelContextAwareLowering {
-        factories.add(factory)
-        return this
-    }
+class ModelContextAwareLowering(private val translationContext: TranslationContext) : ModelLowering {
+    override fun lower(module: ModuleModel): ModuleModel = module
 
     override fun lower(source: SourceSetModel): SourceSetModel {
-        modelContext = ModelContext(source)
-        inheritanceContext = InheritanceContext(modelContext.buildInheritanceGraph())
+        translationContext.initModelContext(ModelContext(source))
+        translationContext.initInheritanceContext(InheritanceContext(translationContext.modelContext.buildInheritanceGraph()))
         return super.lower(source)
+    }
+
+    private fun ModelContext.buildInheritanceGraph(): Graph<ClassLikeModel> {
+        val graph = Graph<ClassLikeModel>()
+
+        getClassLikeIterable().forEach { classLike ->
+            getAllParents(classLike).forEach { resolvedClassLike ->
+                graph.addEdge(classLike, resolvedClassLike.classLike)
+            }
+        }
+
+        return graph
     }
 }

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/ModelLowering.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/ModelLowering.kt
@@ -12,14 +12,6 @@ interface ModelLowering : Lowering<SourceSetModel, SourceSetModel> {
     }
 }
 
-interface ComposableModelLowering : Lowering<SourceSetModel, SourceSetModel> {
-    val lowerings: List<ModelLowering>
-
-    override fun lower(source: SourceSetModel): SourceSetModel {
-        return lowerings.fold(source) { m, lowering -> lowering.lower(m)  }
-    }
-}
-
 fun SourceSetModel.lower(vararg lowerings: Lowering<SourceSetModel, SourceSetModel>): SourceSetModel {
     return lowerings.fold(this) { sourceSet, lowering -> lowering.lower(sourceSet) }
 }

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/TranslationContext.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/TranslationContext.kt
@@ -1,0 +1,30 @@
+package org.jetbrains.dukat.model.commonLowerings
+
+import org.jetbrains.dukat.model.commonLowerings.overrides.InheritanceContext
+
+class TranslationContext {
+    private lateinit var _modelContext: ModelContext
+    private lateinit var _collisionContext: CollisionContext
+    private lateinit var _inheritanceContext: InheritanceContext
+
+    val modelContext: ModelContext
+        get() = _modelContext
+
+    val collisionContext: CollisionContext
+        get() = _collisionContext
+
+    val inheritanceContext: InheritanceContext
+        get() = _inheritanceContext
+
+    fun initModelContext(modelContext: ModelContext) {
+       _modelContext = modelContext
+    }
+
+    fun initInheritanceContext(inheritanceContext: InheritanceContext) {
+        _inheritanceContext = inheritanceContext
+    }
+
+    fun initCollisionContext(collisionContext: CollisionContext) {
+        _collisionContext = collisionContext
+    }
+}

--- a/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/lowerOverrides.kt
+++ b/model-lowerings-common/src/org/jetbrains/dukat/model/commonLowerings/lowerOverrides.kt
@@ -310,7 +310,7 @@ private class ClassLikeOverrideResolver(
         }
 
         val companionObject = classLike.companionObject?.let {
-            ClassLikeOverrideResolver(context, inheritanceContext, it).resolve() as ObjectModel
+            ClassLikeOverrideResolver(translationContext, it).resolve() as ObjectModel
         }
 
         return when (classLike) {

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -179,14 +179,14 @@ private fun translateLambdaParameters(parameters: List<LambdaParameterModel>): S
 fun TypeModel.translate(): String {
     return when (this) {
         is TypeParameterReferenceModel -> {
-            val res = mutableListOf(name.translate(false))
+            val res = mutableListOf(name.translate(shortNameForKotlin = false))
             if (nullable) {
                 res.add("?")
             }
             res.joinToString("")
         }
         is TypeValueModel -> {
-            val res = mutableListOf(value.translate(false))
+            val res = mutableListOf(value.translate(shortNameForKotlin = false))
             if (isGeneric()) {
                 res.add(translateTypeParameters(params))
             }

--- a/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
+++ b/translator-string/src/org/jetbrains/dukat/translatorString/StringTranslator.kt
@@ -179,14 +179,14 @@ private fun translateLambdaParameters(parameters: List<LambdaParameterModel>): S
 fun TypeModel.translate(): String {
     return when (this) {
         is TypeParameterReferenceModel -> {
-            val res = mutableListOf(name.translate())
+            val res = mutableListOf(name.translate(false))
             if (nullable) {
                 res.add("?")
             }
             res.joinToString("")
         }
         is TypeValueModel -> {
-            val res = mutableListOf(value.translate())
+            val res = mutableListOf(value.translate(false))
             if (isGeneric()) {
                 res.add(translateTypeParameters(params))
             }

--- a/typescript/ts-lowerings/build.gradle
+++ b/typescript/ts-lowerings/build.gradle
@@ -10,5 +10,6 @@ dependencies {
     implementation(project(":ts-model"))
     implementation(project(":toposort"))
     implementation(project(":panic"))
-
+    implementation(project(":stdlib"))
+    implementation(project(":model-lowerings-common"))
 }

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/collectKotlinStdlibCollision.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/collectKotlinStdlibCollision.kt
@@ -1,0 +1,80 @@
+package org.jetbrains.dukat.tsLowerings
+
+import TopLevelDeclarationLowering
+import org.jetbrains.dukat.ownerContext.NodeOwner
+import org.jetbrains.dukat.astCommon.IdentifierEntity
+import org.jetbrains.dukat.model.commonLowerings.CollisionContext
+import org.jetbrains.dukat.model.commonLowerings.TranslationContext
+import org.jetbrains.dukat.tsmodel.ClassLikeDeclaration
+import org.jetbrains.dukat.tsmodel.EnumDeclaration
+import org.jetbrains.dukat.tsmodel.ModuleDeclaration
+import org.jetbrains.dukat.tsmodel.SourceSetDeclaration
+import org.jetbrains.dukat.tsmodel.TopLevelDeclaration
+import org.jetbrains.dukat.tsmodel.TypeAliasDeclaration
+import org.jetbrains.dukat.tsmodel.VariableDeclaration
+
+private class KotlinStdlibCollisionCollectingLowering(private val translationContext: TranslationContext): TopLevelDeclarationLowering {
+    private val localCollisionSet = mutableSetOf<String>();
+
+    // TODO: extend list of possible collisions
+    private val stdLibFinalIdentifiers = setOf(
+        "Any",
+        "Boolean",
+        "Nothing",
+        "Number",
+        "String"
+    )
+
+    override fun lowerSourceDeclaration(
+        moduleDeclaration: ModuleDeclaration,
+        owner: NodeOwner<ModuleDeclaration>?
+    ): ModuleDeclaration {
+        return super.lowerSourceDeclaration(moduleDeclaration, owner)
+            .also {
+                if (localCollisionSet.isNotEmpty()) {
+                    translationContext.collisionContext.putFileCollision(moduleDeclaration.uid, localCollisionSet)
+                }
+            }
+    }
+
+    override fun lowerTopLevelDeclaration(
+        declaration: TopLevelDeclaration,
+        owner: NodeOwner<ModuleDeclaration>?
+    ): TopLevelDeclaration? {
+        val name = when (declaration) {
+            is VariableDeclaration -> declaration.name
+            is EnumDeclaration -> declaration.name
+            is ClassLikeDeclaration -> (declaration.name as? IdentifierEntity)?.value
+            is TypeAliasDeclaration -> (declaration.aliasName as? IdentifierEntity)?.value
+            else -> null
+        }
+        return detectCollision(name) {
+            super.lowerTopLevelDeclaration(declaration, owner)
+        }
+    }
+
+    private fun String.isInCollisionWithStdlib(): Boolean {
+        return stdLibFinalIdentifiers.contains(this);
+    }
+
+    private inline fun <R> detectCollision(name: String?, fn: () -> R): R {
+        if (name != null && name.isInCollisionWithStdlib()) {
+            localCollisionSet.add(name);
+        }
+        return fn()
+    }
+}
+
+class CollectKotlinStdlibCollision(private val translationContext: TranslationContext) : TsLowering {
+    init { translationContext.initCollisionContext(CollisionContext()) }
+
+    override fun lower(source: SourceSetDeclaration): SourceSetDeclaration {
+        return source.copy(sources = source.sources.map {
+            it.copy(
+                root = KotlinStdlibCollisionCollectingLowering(translationContext).lowerSourceDeclaration(
+                    it.root
+                )
+            )
+        })
+    }
+}

--- a/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/lowerPrimitives.kt
+++ b/typescript/ts-lowerings/src/org/jetbrains/dukat/tsLowerings/lowerPrimitives.kt
@@ -7,6 +7,7 @@ import org.jetbrains.dukat.model.commonLowerings.LocalCollisions
 import org.jetbrains.dukat.model.commonLowerings.TranslationContext
 import org.jetbrains.dukat.ownerContext.NodeOwner
 import org.jetbrains.dukat.ownerContext.wrap
+import org.jetbrains.dukat.stdlib.KLIBROOT
 import org.jetbrains.dukat.tsmodel.ModuleDeclaration
 import org.jetbrains.dukat.tsmodel.ParameterOwnerDeclaration
 import org.jetbrains.dukat.tsmodel.SourceSetDeclaration
@@ -76,7 +77,7 @@ private class PrimitivesLowering(private val localCollisions: LocalCollisions) :
 
     private fun NameEntity.escapeCollisionIn(localCollisions: LocalCollisions): NameEntity {
         return if (this is IdentifierEntity && localCollisions.contains(value)) {
-            QualifierEntity(IdentifierEntity("kotlin"), this)
+            QualifierEntity(KLIBROOT, this)
         } else {
             this
         }

--- a/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
+++ b/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/introduceModels.kt
@@ -53,6 +53,7 @@ import org.jetbrains.dukat.moduleNameResolver.ModuleNameResolver
 import org.jetbrains.dukat.panic.raiseConcern
 import org.jetbrains.dukat.stdlib.KLIBROOT
 import org.jetbrains.dukat.stdlib.KotlinStdlibEntities
+import org.jetbrains.dukat.stdlib.isKotlinStdlibPrefixed
 import org.jetbrains.dukat.translatorString.translate
 import org.jetbrains.dukat.tsmodel.CallSignatureDeclaration
 import org.jetbrains.dukat.tsmodel.ClassDeclaration
@@ -256,7 +257,15 @@ private class DocumentConverter(
     private fun TypeAliasDeclaration.isRedundant(typeResolved: TypeModel): Boolean {
         return typeResolved is TypeValueModel &&
                 typeResolved.params.isEmpty() && typeParameters.isEmpty() && !typeResolved.nullable &&
-                typeResolved.value == aliasName
+                typeResolved.value.asKotlinTypeRef() == aliasName
+    }
+
+    private fun NameEntity.asKotlinTypeRef(): NameEntity {
+       return if (isKotlinStdlibPrefixed()) {
+           rightMost()
+       } else {
+           this
+       }
     }
 
     private fun ReferenceEntity.getFqName(): NameEntity? {


### PR DESCRIPTION
### Summary

Those changes solve the problem with identifiers hidden with TypeScript definitions. For example:
```ts
declare interface Any {
  id(a: any): Any;
}
```
This code snippet is translated into the next one:
```kotlin
external interface Any {
  fun id(a: Any): Any
}
```
But proposed behaviors is to translate it into:
```kotlin
external interface Any {
  fun id(a: kotlin.Any): Any
}
```

### Related Issue

https://github.com/Kotlin/dukat/issues/381
