### PR TITLE
fix(Interface Readonly): convert interface's and object type's readonly properties into val.

### DIFF
--- a/compiler/test/data/typescript/node_modules/class/variables/variables.d.kt
+++ b/compiler/test/data/typescript/node_modules/class/variables/variables.d.kt
@@ -21,4 +21,9 @@ external open class Foo {
     open var varAsNumber: Number
     open var varAsBoolean: Boolean
     open var varAsString: String
+    open val valWithoutTypeAnnotation: Any
+    open val valAsAny: Any
+    open val valAsNumber: Number
+    open val valAsBoolean: Boolean
+    open val valAsString: String
 }

--- a/compiler/test/data/typescript/node_modules/class/variables/variables.d.ts
+++ b/compiler/test/data/typescript/node_modules/class/variables/variables.d.ts
@@ -4,4 +4,9 @@ declare class Foo {
     varAsNumber: number;
     varAsBoolean: boolean;
     varAsString: string;
+    readonly valWithoutTypeAnnotation;
+    readonly valAsAny: any;
+    readonly valAsNumber: number;
+    readonly valAsBoolean: boolean;
+    readonly valAsString: string;
 }

--- a/compiler/test/data/typescript/node_modules/interface/variables/variables.d.kt
+++ b/compiler/test/data/typescript/node_modules/interface/variables/variables.d.kt
@@ -22,6 +22,12 @@ external interface Foo {
     var varAsBoolean: Boolean
     var varAsString: String
     var varAsSimpleLambda: (force: Boolean) -> Unit
+    val valWithoutTypeAnnotation: Any
+    val valAsAny: Any
+    val valAsNumber: Number
+    val valAsBoolean: Boolean
+    val valAsString: String
+    val valAsSimpleLambda: (force: Boolean) -> Unit
 }
 
 // ------------------------------------------------------------------------------------------
@@ -45,4 +51,5 @@ import org.w3c.xhr.*
 
 external interface Bar {
     var name: String
+    val immutableName: String
 }

--- a/compiler/test/data/typescript/node_modules/interface/variables/variables.d.ts
+++ b/compiler/test/data/typescript/node_modules/interface/variables/variables.d.ts
@@ -5,9 +5,17 @@ interface Foo {
     varAsBoolean: boolean;
     varAsString: string;
     varAsSimpleLambda: (force: boolean) => void;
+
+    readonly valWithoutTypeAnnotation;
+    readonly valAsAny: any;
+    readonly valAsNumber: number;
+    readonly valAsBoolean: boolean;
+    readonly valAsString: string;
+    readonly valAsSimpleLambda: (force: boolean) => void;
 }
 declare namespace foo {
     interface Bar {
         name: string;
+        readonly immutableName: string;
     }
 }

--- a/compiler/test/data/typescript/node_modules/objectType/var.d.kt
+++ b/compiler/test/data/typescript/node_modules/objectType/var.d.kt
@@ -24,6 +24,9 @@ external object foo {
     var baz: Any
     var boo: String
     var show: (overrideChecks: Boolean) -> Unit
+    val ibaz: Any
+    val iboo: String
+    val ishow: (overrideChecks: Boolean) -> Unit
     @nativeInvoke
     operator fun invoke(foo: `T$0`): Any
     @nativeGetter

--- a/compiler/test/data/typescript/node_modules/objectType/var.d.ts
+++ b/compiler/test/data/typescript/node_modules/objectType/var.d.ts
@@ -3,6 +3,9 @@ declare var foo: {
     baz;
     boo: string;
     show: (overrideChecks: boolean) => void;
+    readonly ibaz;
+    readonly iboo: string;
+    readonly ishow: (overrideChecks: boolean) => void;
     (foo: {bar : number}): {};
     [s: string]: any;
 };

--- a/typescript/ts-converter/src/AstConverter.ts
+++ b/typescript/ts-converter/src/AstConverter.ts
@@ -593,13 +593,14 @@ export class AstConverter {
     let name = this.convertName(node.name);
 
     if (name !== null) {
-      return this.createProperty(
+      return this.astFactory.declareProperty(
           name,
           node.initializer ?
               this.astExpressionConverter.convertExpression(node.initializer) : null,
           this.convertType(node.type),
           [],
           !!node.questionToken,
+          this.convertModifiers(node.modifiers),
           node.type != undefined
       );
     }


### PR DESCRIPTION
### Summary

There is a bug in the interface and object types conversion: readonly members will be translated into `var` instead of `val`.
Example:
```ts
declare interface A {
  readonly a: number;
}
```
Actual:
```kotlin
external interface A {
  var a: Number
}
```

Expected:
```kotlin
external interface A {
  val a: Number
}
```
