### PR TITLE
Fix NumberFormatException when translating numeric literals

### DIFF
--- a/ast-model/src/org/jetbrains/dukat/astModel/expressions/literals/NumericLiteralExpressionModel.kt
+++ b/ast-model/src/org/jetbrains/dukat/astModel/expressions/literals/NumericLiteralExpressionModel.kt
@@ -1,5 +1,5 @@
 package org.jetbrains.dukat.astModel.expressions.literals
 
 data class NumericLiteralExpressionModel(
-    val value: Int
+    val value: Number
 ): LiteralExpressionModel

--- a/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/convertStatements.kt
+++ b/typescript/ts-model-introduction/src/org/jetbrains/dukat/nodeIntroduction/convertStatements.kt
@@ -126,7 +126,7 @@ class ExpressionConverter(private val typeConverter: (ParameterValueDeclaration)
                 value
             )
             is NumericLiteralExpressionDeclaration -> NumericLiteralExpressionModel(
-                value.toInt()
+                if (value.contains('.')) value.toDouble() else value.toInt()
             )
             is BooleanLiteralExpressionDeclaration -> BooleanLiteralExpressionModel(
                 value


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [x] Code is up-to-date with the `main` branch
* [ ] There are new or updated unit tests validating those changes
* [x] You've successfully run `./gradlew build` locally

And finally, please fill out this entire template so that we can review your PR as quickly as possible.
-->

### Summary

This PR fixes a problem with converting numeric literals with a decimal point (e.g. "1.5").

With the current master, converting API wrappers for [Babylon.js](https://www.npmjs.com/package/@babylonjs/core) fails due to a `NumberFormatException` caused by trying to parse lines such as below:
```typescript
static readonly _DefaultIndexOfRefraction = 1.5;
```

### Related Issue

<!-- 
Please, leave the issue link related to the PR.
If there is no issue for those changes, please, create the issue.
-->
#487 
