### PR TITLE
Short-circuit module conversion if it has no body

### DIFF
--- a/typescript/ts-converter/src/AstConverter.ts
+++ b/typescript/ts-converter/src/AstConverter.ts
@@ -1155,6 +1155,6 @@ export class AstConverter {
   }
 
   private convertModule(module: ts.ModuleDeclaration, filter?: (node: ts.Node) => boolean): TopLevelDeclarationProto | null {
-    return this.convertModuleBody(module.body, filter);
+    return module.body && this.convertModuleBody(module.body, filter);
   }
 }


### PR DESCRIPTION
Otherwise converting [ace-builds](https://www.npmjs.com/package/ace-builds) fails with `TypeError: Cannot read properties of undefined (reading 'kind')`.

### Summary

Check that a module has a body before attempting to convert it. I don't see any closely-related unit tests to add to, sorry.

### Related Issue

#508