### PR TITLE
Fix generation of descriptors when some type contains error.

### DIFF
--- a/descriptors/src/org/jetbrains/dukat/descriptors/CustomClassDescriptor.kt
+++ b/descriptors/src/org/jetbrains/dukat/descriptors/CustomClassDescriptor.kt
@@ -46,7 +46,7 @@ open class CustomClassDescriptor(
         LockBasedStorageManager.NO_LOCKS
     ) {
 
-    private val typeConstructor by lazy {
+    private var typeConstructor = lazy<TypeConstructor> {
         ClassTypeConstructorImpl(this, typeParameters, parentTypes, LockBasedStorageManager.NO_LOCKS)
     }
 
@@ -69,7 +69,11 @@ open class CustomClassDescriptor(
     }
 
     override fun getTypeConstructor(): TypeConstructor {
-        return typeConstructor
+        return typeConstructor.value
+    }
+
+    fun setTypeConstructor(value: TypeConstructor) {
+        typeConstructor = lazy { value }
     }
 
     override fun getConstructors(): Collection<ClassConstructorDescriptor> {

--- a/descriptors/src/org/jetbrains/dukat/descriptors/removeErrorDescriptors.kt
+++ b/descriptors/src/org/jetbrains/dukat/descriptors/removeErrorDescriptors.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.types.AbbreviatedType
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.getAbbreviation
 import org.jetbrains.kotlin.types.isError
 
 private fun KotlinType.containsError(): Boolean {
@@ -20,7 +21,7 @@ private fun TypeParameterDescriptor.containsError(): Boolean {
 }
 
 private fun CallableMemberDescriptor.containsError(): Boolean {
-    return (valueParameters.map { it.type } + returnType).filterNotNull().any { it.containsError() } ||
+    return (valueParameters.map { it.type } + returnType + returnType?.getAbbreviation()).filterNotNull().any { it.containsError() } ||
             typeParameters.any { it.containsError() }
 }
 

--- a/descriptors/src/org/jetbrains/dukat/descriptors/writeDescriptorsToFile.kt
+++ b/descriptors/src/org/jetbrains/dukat/descriptors/writeDescriptorsToFile.kt
@@ -113,6 +113,7 @@ fun writeDescriptorsToFile(sourceSet: SourceSetModel, stdLib: String, outputDirP
 
     return convertToDescriptors(sourceSet, stdLib).map { outputFile ->
         val output = outputDir.resolve(outputFile.relativePath)
+        output.parentFile.mkdirs()
         output.writeBytes(outputFile.asByteArray())
         outputFile.relativePath
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

* [ ] Code is up-to-date with the `main` branch
* [ ] There are new or updated unit tests validating those changes
* [ ] You've successfully run `./gradlew build` locally

And finally, please fill out this entire template so that we can review your PR as quickly as possible.
-->

### Summary

<!--- Short summary of your changes -->
Fix generation of descriptors when some type contains error.

#### Steps to reproduce
Discovered errors while trying to convert vue 3.3.4. The steps to reproduce are the follwing:
```shell
git clone https://github.com/Kotlin/dukat.git
cd dukat
mkdir test-vue-conversion
cd test-vue-conversion
export PROJECT_HOME=$(pwd)
npm install vue@3.3.4
cd ..
./gradlew build :node-package:buildDistrib -x test
cd node-package/build/distrib/bin
node dukat-cli.js --descriptors -p dw -d $PROJECT_HOME/src/js/kotlin/ $PROJECT_HOME/node_modules/vue/dist/vue.d.ts
```

It crashes with the following exception:
```
Exception in thread "main" java.lang.IllegalStateException: Cannot serialize error type: [ERROR : Directive]
        at org.jetbrains.kotlin.serialization.SerializerExtension.serializeErrorType(SerializerExtension.kt:93)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.type$serialization(DescriptorSerializer.kt:553)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.typeArgument(DescriptorSerializer.kt:649)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.fillFromPossiblyInnerType(DescriptorSerializer.kt:620)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.type$serialization(DescriptorSerializer.kt:580)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.type$serialization(DescriptorSerializer.kt:602)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.propertyProto(DescriptorSerializer.kt:257)
        at org.jetbrains.kotlin.serialization.DescriptorSerializer.classProto(DescriptorSerializer.kt:116)
        at org.jetbrains.kotlin.serialization.js.KotlinJavascriptSerializationUtil.serializeDescriptors$serializeClasses(KotlinJavascriptSerializationUtil.kt:192)
        at org.jetbrains.kotlin.serialization.js.KotlinJavascriptSerializationUtil.serializeDescriptors(KotlinJavascriptSerializationUtil.kt:198)
        at org.jetbrains.kotlin.serialization.js.KotlinJavascriptSerializationUtilKt.missingMetadata(KotlinJavascriptSerializationUtil.kt:319)
        at org.jetbrains.kotlin.serialization.js.KotlinJavascriptSerializationUtil.serializeMetadata(KotlinJavascriptSerializationUtil.kt:69)
        at org.jetbrains.dukat.descriptors.WriteDescriptorsToFileKt.convertToDescriptors(writeDescriptorsToFile.kt:59)
        at org.jetbrains.dukat.descriptors.WriteDescriptorsToFileKt.writeDescriptorsToFile(writeDescriptorsToFile.kt:114)
        at org.jetbrains.dukat.cli.CliKt.main(cli.kt:292)
```

#### Additional info:
```shell
$ java -version
openjdk version "1.8.0_342"
OpenJDK Runtime Environment (Zulu 8.64.0.15-CA-linux64) (build 1.8.0_342-b07)
OpenJDK 64-Bit Server VM (Zulu 8.64.0.15-CA-linux64) (build 25.342-b07, mixed mode)

$ node --version
v18.14.1
```

### Related Issue

<!-- 
Please, leave the issue link related to the PR.
If there is no issue for those changes, please, create the issue.
-->
Maybe related to [https://github.com/Kotlin/dukat/issues/477](https://github.com/Kotlin/dukat/issues/477)
